### PR TITLE
Fix legacy rules for new @vitest/eslint-plugin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you're using old Eslint configuration, make sure to use legacy key like the f
 
 ```js
 {
-  "extends": ["plugin:vitest/legacy-recommended"] // or legacy-all
+  "extends": ["plugin:@vitest/legacy-recommended"] // or legacy-all
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,11 +72,11 @@ const createConfig = <R extends Linter.RulesRecord>(rules: R) => (
   }
 
 const createConfigLegacy = (rules: Record<string, string>) => ({
-  plugins: ['vitest'],
+  plugins: ['@vitest'],
   rules: Object.keys(rules).reduce((acc, ruleName) => {
     return {
       ...acc,
-      [`vitest/${ruleName}`]: rules[ruleName]
+      [`@vitest/${ruleName}`]: rules[ruleName]
     }
   }, {})
 })


### PR DESCRIPTION
Adding `"extends": ["plugin:vitest/legacy-recommended"]` to your `.eslintrc` results in:
> ESLint couldn't find the plugin "eslint-plugin-vitest".

Once switched to `plugin:@vitest/legacy-recommended` the error persists because `createConfigLegacy` itself has the value `plugins: ['vitest']`.

After fixing that you will get errors like:
> error  Definition for rule 'vitest/prefer-to-be' was not found

This is fixed by correcting the rule name prefix in `createConfigLegacy`.