### PR TITLE
fixed instructions for legacy plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add `vitest` to the plugins section of your `.eslintrc` configuration file. You 
 
 ```json
 {
-  "plugins": ["vitest"]
+  "plugins": ["@vitest"]
 }
 ```
 


### PR DESCRIPTION
this PR fixes the instructions for the plugin name.

the current instructions
```
plugins: ['@vitest']
```
give this error when running `npm run lint` in a package:
```
Oops! Something went wrong! :(

ESLint: 9.8.0

ESLint couldn't find the plugin "eslint-plugin-vitest".

(The package "eslint-plugin-vitest" was not found when loaded as a Node module from the directory "/Users/yair/p/vite-app-template".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm install eslint-plugin-vitest@latest --save-dev
...
```
