### PR TITLE
docs: fix outdated rule names in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export default [
     },
     rules: {
       ...vitest.configs.recommended.rules, // you can also use vitest.configs.all.rules to enable all rules
-      "vitest/max-nested-describe": ["error", { "max": 3 }] // you can also modify rules' behavior using option like this
+      "@vitest/max-nested-describe": ["error", { "max": 3 }] // you can also modify rules' behavior using option like this
     },
   },
 ];
@@ -55,7 +55,7 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "vitest/max-nested-describe": [
+    "@vitest/max-nested-describe": [
       "error",
       {
         "max": 3

--- a/docs/rules/assertion-type.md
+++ b/docs/rules/assertion-type.md
@@ -1,4 +1,4 @@
-# Enforce assertion type (`vitest/assertion-type`)
+# Enforce assertion type (`@vitest/assertion-type`)
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/consistent-test-filename.md
+++ b/docs/rules/consistent-test-filename.md
@@ -1,4 +1,4 @@
-# Require .spec test file pattern (`vitest/consistent-test-filename`)
+# Require .spec test file pattern (`@vitest/consistent-test-filename`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/consistent-test-it.md
+++ b/docs/rules/consistent-test-it.md
@@ -1,4 +1,4 @@
-# Enforce using test or it but not both (`vitest/consistent-test-it`)
+# Enforce using test or it but not both (`@vitest/consistent-test-it`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -1,4 +1,4 @@
-# Enforce having expectation in test body (`vitest/expect-expect`)
+# Enforce having expectation in test body (`@vitest/expect-expect`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/max-expect.md
+++ b/docs/rules/max-expect.md
@@ -1,4 +1,4 @@
-# Enforce a maximum number of expect per test (`vitest/max-expect`)
+# Enforce a maximum number of expect per test (`@vitest/max-expect`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/max-expects.md
+++ b/docs/rules/max-expects.md
@@ -1,4 +1,4 @@
-# Enforce a maximum number of expect per test (`vitest/max-expects`)
+# Enforce a maximum number of expect per test (`@vitest/max-expects`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/max-nested-describe.md
+++ b/docs/rules/max-nested-describe.md
@@ -1,4 +1,4 @@
-# Require describe block to be less than set max value or default value (`vitest/max-nested-describe`)
+# Require describe block to be less than set max value or default value (`@vitest/max-nested-describe`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-alias-methods.md
+++ b/docs/rules/no-alias-methods.md
@@ -1,4 +1,4 @@
-# Disallow alias methods (`vitest/no-alias-methods`)
+# Disallow alias methods (`@vitest/no-alias-methods`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-commented-out-tests.md
+++ b/docs/rules/no-commented-out-tests.md
@@ -1,4 +1,4 @@
-# Disallow commented out tests (`vitest/no-commented-out-tests`)
+# Disallow commented out tests (`@vitest/no-commented-out-tests`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/no-conditional-expect.md
+++ b/docs/rules/no-conditional-expect.md
@@ -1,4 +1,4 @@
-# Disallow conditional expects (`vitest/no-conditional-expect`)
+# Disallow conditional expects (`@vitest/no-conditional-expect`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-conditional-in-test.md
+++ b/docs/rules/no-conditional-in-test.md
@@ -1,4 +1,4 @@
-# Disallow conditional tests (`vitest/no-conditional-in-test`)
+# Disallow conditional tests (`@vitest/no-conditional-in-test`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-conditional-tests.md
+++ b/docs/rules/no-conditional-tests.md
@@ -1,4 +1,4 @@
-# Disallow conditional tests (`vitest/no-conditional-tests`)
+# Disallow conditional tests (`@vitest/no-conditional-tests`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-disabled-tests.md
+++ b/docs/rules/no-disabled-tests.md
@@ -1,4 +1,4 @@
-# Disallow disabled tests (`vitest/no-disabled-tests`)
+# Disallow disabled tests (`@vitest/no-disabled-tests`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-done-callback.md
+++ b/docs/rules/no-done-callback.md
@@ -1,4 +1,4 @@
-# Disallow using a callback in asynchronous tests and hooks (`vitest/no-done-callback`)
+# Disallow using a callback in asynchronous tests and hooks (`@vitest/no-done-callback`)
 
 ❌ This rule is deprecated.
 

--- a/docs/rules/no-duplicate-hooks.md
+++ b/docs/rules/no-duplicate-hooks.md
@@ -1,4 +1,4 @@
-# Disallow duplicate hooks and teardown hooks (`vitest/no-duplicate-hooks`)
+# Disallow duplicate hooks and teardown hooks (`@vitest/no-duplicate-hooks`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-focused-tests.md
+++ b/docs/rules/no-focused-tests.md
@@ -1,4 +1,4 @@
-# Disallow focused tests (`vitest/no-focused-tests`)
+# Disallow focused tests (`@vitest/no-focused-tests`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-hooks.md
+++ b/docs/rules/no-hooks.md
@@ -1,4 +1,4 @@
-# Disallow setup and teardown hooks (`vitest/no-hooks`)
+# Disallow setup and teardown hooks (`@vitest/no-hooks`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-identical-title.md
+++ b/docs/rules/no-identical-title.md
@@ -1,4 +1,4 @@
-# Disallow identical titles (`vitest/no-identical-title`)
+# Disallow identical titles (`@vitest/no-identical-title`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/no-import-node-test.md
+++ b/docs/rules/no-import-node-test.md
@@ -1,4 +1,4 @@
-# Disallow importing `node:test` (`vitest/no-import-node-test`)
+# Disallow importing `node:test` (`@vitest/no-import-node-test`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/no-interpolation-in-snapshots.md
+++ b/docs/rules/no-interpolation-in-snapshots.md
@@ -1,4 +1,4 @@
-# Disallow string interpolation in snapshots (`vitest/no-interpolation-in-snapshots`)
+# Disallow string interpolation in snapshots (`@vitest/no-interpolation-in-snapshots`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-large-snapshots.md
+++ b/docs/rules/no-large-snapshots.md
@@ -1,4 +1,4 @@
-# Disallow large snapshots (`vitest/no-large-snapshots`)
+# Disallow large snapshots (`@vitest/no-large-snapshots`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-mocks-import.md
+++ b/docs/rules/no-mocks-import.md
@@ -1,4 +1,4 @@
-# Disallow importing from __mocks__ directory (`vitest/no-mocks-import`)
+# Disallow importing from __mocks__ directory (`@vitest/no-mocks-import`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-restricted-matchers.md
+++ b/docs/rules/no-restricted-matchers.md
@@ -1,4 +1,4 @@
-# Disallow the use of certain matchers (`vitest/no-restricted-matchers`)
+# Disallow the use of certain matchers (`@vitest/no-restricted-matchers`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-restricted-vi-methods.md
+++ b/docs/rules/no-restricted-vi-methods.md
@@ -1,4 +1,4 @@
-# Disallow specific `vi.` methods (`vitest/no-restricted-vi-methods`)
+# Disallow specific `vi.` methods (`@vitest/no-restricted-vi-methods`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-standalone-expect.md
+++ b/docs/rules/no-standalone-expect.md
@@ -1,4 +1,4 @@
-# Disallow using `expect` outside of `it` or `test` blocks (`vitest/no-standalone-expect`)
+# Disallow using `expect` outside of `it` or `test` blocks (`@vitest/no-standalone-expect`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-test-prefixes.md
+++ b/docs/rules/no-test-prefixes.md
@@ -1,4 +1,4 @@
-# Disallow using `test` as a prefix (`vitest/no-test-prefixes`)
+# Disallow using `test` as a prefix (`@vitest/no-test-prefixes`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/no-test-return-statement.md
+++ b/docs/rules/no-test-return-statement.md
@@ -1,4 +1,4 @@
-# Disallow return statements in tests (`vitest/no-test-return-statement`)
+# Disallow return statements in tests (`@vitest/no-test-return-statement`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-called-with.md
+++ b/docs/rules/prefer-called-with.md
@@ -1,4 +1,4 @@
-# Enforce using `toBeCalledWith()` or `toHaveBeenCalledWith()` (`vitest/prefer-called-with`)
+# Enforce using `toBeCalledWith()` or `toHaveBeenCalledWith()` (`@vitest/prefer-called-with`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-comparison-matcher.md
+++ b/docs/rules/prefer-comparison-matcher.md
@@ -1,4 +1,4 @@
-# Enforce using the built-in comparison matchers (`vitest/prefer-comparison-matcher`)
+# Enforce using the built-in comparison matchers (`@vitest/prefer-comparison-matcher`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-each.md
+++ b/docs/rules/prefer-each.md
@@ -1,4 +1,4 @@
-# Enforce using `each` rather than manual loops (`vitest/prefer-each`)
+# Enforce using `each` rather than manual loops (`@vitest/prefer-each`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-equality-matcher.md
+++ b/docs/rules/prefer-equality-matcher.md
@@ -1,4 +1,4 @@
-# Enforce using the built-in quality matchers (`vitest/prefer-equality-matcher`)
+# Enforce using the built-in quality matchers (`@vitest/prefer-equality-matcher`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-expect-assertions.md
+++ b/docs/rules/prefer-expect-assertions.md
@@ -1,4 +1,4 @@
-# Enforce using expect assertions instead of callbacks (`vitest/prefer-expect-assertions`)
+# Enforce using expect assertions instead of callbacks (`@vitest/prefer-expect-assertions`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-expect-resolves.md
+++ b/docs/rules/prefer-expect-resolves.md
@@ -1,4 +1,4 @@
-# Enforce using `expect().resolves` over `expect(await ...)` syntax (`vitest/prefer-expect-resolves`)
+# Enforce using `expect().resolves` over `expect(await ...)` syntax (`@vitest/prefer-expect-resolves`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-hooks-in-order.md
+++ b/docs/rules/prefer-hooks-in-order.md
@@ -1,4 +1,4 @@
-# Enforce having hooks in consistent order (`vitest/prefer-hooks-in-order`)
+# Enforce having hooks in consistent order (`@vitest/prefer-hooks-in-order`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-hooks-on-top.md
+++ b/docs/rules/prefer-hooks-on-top.md
@@ -1,4 +1,4 @@
-# Enforce having hooks before any test cases (`vitest/prefer-hooks-on-top`)
+# Enforce having hooks before any test cases (`@vitest/prefer-hooks-on-top`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-lowercase-title.md
+++ b/docs/rules/prefer-lowercase-title.md
@@ -1,4 +1,4 @@
-# Enforce lowercase titles (`vitest/prefer-lowercase-title`)
+# Enforce lowercase titles (`@vitest/prefer-lowercase-title`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-mock-promise-shorthand.md
+++ b/docs/rules/prefer-mock-promise-shorthand.md
@@ -1,4 +1,4 @@
-# Enforce mock resolved/rejected shorthands for promises (`vitest/prefer-mock-promise-shorthand`)
+# Enforce mock resolved/rejected shorthands for promises (`@vitest/prefer-mock-promise-shorthand`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-snapshot-hint.md
+++ b/docs/rules/prefer-snapshot-hint.md
@@ -1,4 +1,4 @@
-# Enforce including a hint with external snapshots (`vitest/prefer-snapshot-hint`)
+# Enforce including a hint with external snapshots (`@vitest/prefer-snapshot-hint`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-spy-on.md
+++ b/docs/rules/prefer-spy-on.md
@@ -1,4 +1,4 @@
-# Enforce using `vi.spyOn` (`vitest/prefer-spy-on`)
+# Enforce using `vi.spyOn` (`@vitest/prefer-spy-on`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-strict-equal.md
+++ b/docs/rules/prefer-strict-equal.md
@@ -1,4 +1,4 @@
-# Enforce strict equal over equal (`vitest/prefer-strict-equal`)
+# Enforce strict equal over equal (`@vitest/prefer-strict-equal`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-to-be-falsy.md
+++ b/docs/rules/prefer-to-be-falsy.md
@@ -1,4 +1,4 @@
-# Enforce using toBeFalsy() (`vitest/prefer-to-be-falsy`)
+# Enforce using toBeFalsy() (`@vitest/prefer-to-be-falsy`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-to-be-object.md
+++ b/docs/rules/prefer-to-be-object.md
@@ -1,4 +1,4 @@
-# Enforce using toBeObject() (`vitest/prefer-to-be-object`)
+# Enforce using toBeObject() (`@vitest/prefer-to-be-object`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-to-be-truthy.md
+++ b/docs/rules/prefer-to-be-truthy.md
@@ -1,4 +1,4 @@
-# Enforce using `toBeTruthy` (`vitest/prefer-to-be-truthy`)
+# Enforce using `toBeTruthy` (`@vitest/prefer-to-be-truthy`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-to-be.md
+++ b/docs/rules/prefer-to-be.md
@@ -1,4 +1,4 @@
-# Enforce using toBe() (`vitest/prefer-to-be`)
+# Enforce using toBe() (`@vitest/prefer-to-be`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-to-contain.md
+++ b/docs/rules/prefer-to-contain.md
@@ -1,4 +1,4 @@
-# Enforce using toContain() (`vitest/prefer-to-contain`)
+# Enforce using toContain() (`@vitest/prefer-to-contain`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-to-have-length.md
+++ b/docs/rules/prefer-to-have-length.md
@@ -1,4 +1,4 @@
-# Enforce using toHaveLength() (`vitest/prefer-to-have-length`)
+# Enforce using toHaveLength() (`@vitest/prefer-to-have-length`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/prefer-todo.md
+++ b/docs/rules/prefer-todo.md
@@ -1,4 +1,4 @@
-# Enforce using `test.todo` (`vitest/prefer-todo`)
+# Enforce using `test.todo` (`@vitest/prefer-todo`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/require-hook.md
+++ b/docs/rules/require-hook.md
@@ -1,4 +1,4 @@
-# Require setup and teardown to be within a hook (`vitest/require-hook`)
+# Require setup and teardown to be within a hook (`@vitest/require-hook`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/require-local-test-context-for-concurrent-snapshots.md
+++ b/docs/rules/require-local-test-context-for-concurrent-snapshots.md
@@ -1,4 +1,4 @@
-# Require local Test Context for concurrent snapshot tests (`vitest/require-local-test-context-for-concurrent-snapshots`)
+# Require local Test Context for concurrent snapshot tests (`@vitest/require-local-test-context-for-concurrent-snapshots`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/require-to-throw-message.md
+++ b/docs/rules/require-to-throw-message.md
@@ -1,4 +1,4 @@
-# Require toThrow() to be called with an error message (`vitest/require-to-throw-message`)
+# Require toThrow() to be called with an error message (`@vitest/require-to-throw-message`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/require-top-level-describe.md
+++ b/docs/rules/require-top-level-describe.md
@@ -1,4 +1,4 @@
-# Enforce that all tests are in a top-level describe (`vitest/require-top-level-describe`)
+# Enforce that all tests are in a top-level describe (`@vitest/require-top-level-describe`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/unbound-method.md
+++ b/docs/rules/unbound-method.md
@@ -1,4 +1,4 @@
-# Enforce unbound methods are called with their expected scope (`vitest/unbound-method`)
+# Enforce unbound methods are called with their expected scope (`@vitest/unbound-method`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/valid-describe-callback.md
+++ b/docs/rules/valid-describe-callback.md
@@ -1,4 +1,4 @@
-# Enforce valid describe callback (`vitest/valid-describe-callback`)
+# Enforce valid describe callback (`@vitest/valid-describe-callback`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -1,4 +1,4 @@
-# Enforce valid `expect()` usage (`vitest/valid-expect`)
+# Enforce valid `expect()` usage (`@vitest/valid-expect`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -1,4 +1,4 @@
-# Enforce valid titles (`vitest/valid-title`)
+# Enforce valid titles (`@vitest/valid-title`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 


### PR DESCRIPTION
I noticed a small typo in the documentation.
Since the change from `eslint-plugin-vitest` to `@vitest/eslint-plugin`, the name of the rules has changed from `vitest/rule` to `@vitest/rule`.
However, this was not noted in the documentation, which can be misleading.

This small PR corrects that.