### PR TITLE
fix(valid-describe-callback): remove `noAsyncDescribeCallback`

### DIFF
--- a/docs/rules/valid-describe-callback.md
+++ b/docs/rules/valid-describe-callback.md
@@ -7,18 +7,12 @@
 
 This rule validates the second parameter of a `describe()` function is a callback. 
 
-- should not be async 
 - should not contain parameters 
 - should not contain  any `return` statements
 
 The following are considered warnings:
 
 ```js
-// async callback functions are not allowed
-describe("myfunc", async () => {
-	// 
-})
-
 // callback function parameters are not allowed
 describe("myfunc", done => {
 	// 
@@ -43,6 +37,11 @@ describe("myfunc", () => {
 The following are not considered warnings:
 
 ```js
+describe("myfunc", async () => {
+    it("should do something", () => {
+        // 
+    })
+})
 describe("myfunc", () => {
 	it("should do something", () => {
 		// 

--- a/docs/rules/valid-describe-callback.md
+++ b/docs/rules/valid-describe-callback.md
@@ -38,9 +38,7 @@ The following are not considered warnings:
 
 ```js
 describe("myfunc", async () => {
-    it("should do something", () => {
-        // 
-    })
+    //
 })
 describe("myfunc", () => {
 	it("should do something", () => {

--- a/src/rules/valid-describe-callback.ts
+++ b/src/rules/valid-describe-callback.ts
@@ -6,7 +6,6 @@ export const RULE_NAME = 'valid-describe-callback'
 type MESSAGE_IDS =
   | 'nameAndCallback'
   | 'secondArgumentMustBeFunction'
-  | 'noAsyncDescribeCallback'
   | 'unexpectedDescribeArgument'
   | 'unexpectedReturnInDescribe'
 
@@ -33,7 +32,6 @@ export default createEslintRule<Options, MESSAGE_IDS>({
     messages: {
       nameAndCallback: 'Describe requires a name and callback arguments',
       secondArgumentMustBeFunction: 'Second argument must be a function',
-      noAsyncDescribeCallback: 'Describe callback cannot be async',
       unexpectedDescribeArgument: 'Unexpected argument in describe callback',
       unexpectedReturnInDescribe: 'Unexpected return statement in describe callback'
     },
@@ -73,13 +71,6 @@ export default createEslintRule<Options, MESSAGE_IDS>({
             loc: paramsLocation(node.arguments)
           })
           return
-        }
-
-        if (callback.async) {
-          context.report({
-            messageId: 'noAsyncDescribeCallback',
-            node: callback
-          })
         }
 
         if (vitestFnCall.members.every(s => getAccessorValue(s) !== 'each')

--- a/tests/valid-describe-callback.test.ts
+++ b/tests/valid-describe-callback.test.ts
@@ -37,6 +37,25 @@ ruleTester.run(RULE_NAME, rule, {
         foo  | foe
         ${1} | ${2}
       \`('$something', ({ foo, foe }) => {});
+    `,
+    // https://github.com/vitest-dev/eslint-plugin-vitest/issues/511
+    'describe("foo", async () => {})',
+    'describe("foo", async function () {})',
+    'xdescribe("foo", async function () {})',
+    'fdescribe("foo", async function () {})',
+    'describe.only("foo", async function () {})',
+    'describe.skip("foo", async function () {})',
+    `describe('sample case', () => {
+        it('works', () => {
+          expect(true).toEqual(true);
+        });
+        describe('async', () => {
+          it('works', async () => {
+            await new Promise(setImmediate);
+            expect(true).toEqual(true);
+          });
+        });
+      });
     `
   ],
   invalid: [
@@ -91,46 +110,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: 'nameAndCallback', line: 1, column: 1 }]
     },
     {
-      code: 'describe("foo", async () => {})',
-      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 17 }]
-    },
-    {
-      code: 'describe("foo", async function () {})',
-      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 17 }]
-    },
-    {
-      code: 'xdescribe("foo", async function () {})',
-      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 18 }]
-    },
-    {
-      code: 'fdescribe("foo", async function () {})',
-      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 18 }]
-    },
-    {
-      code: 'describe.only("foo", async function () {})',
-      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 22 }]
-    },
-    {
-      code: 'describe.skip("foo", async function () {})',
-      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 22 }]
-    },
-    {
-      code: `
-       describe('sample case', () => {
-      it('works', () => {
-        expect(true).toEqual(true);
-      });
-      describe('async', async () => {
-        await new Promise(setImmediate);
-        it('breaks', () => {
-       throw new Error('Fail');
-        });
-      });
-       });
-     `,
-      errors: [{ messageId: 'noAsyncDescribeCallback', line: 6, column: 25 }]
-    },
-    {
       code: `
        describe('foo', function () {
       return Promise.resolve().then(() => {
@@ -179,7 +158,6 @@ ruleTester.run(RULE_NAME, rule, {
        })
      `,
       errors: [
-        { messageId: 'noAsyncDescribeCallback', line: 2, column: 24 },
         { messageId: 'unexpectedReturnInDescribe', line: 6, column: 9 }
       ]
     },
@@ -214,7 +192,6 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: 'describe("foo", async function (done) {})',
       errors: [
-        { messageId: 'noAsyncDescribeCallback', line: 1, column: 17 },
         { messageId: 'unexpectedDescribeArgument', line: 1, column: 17 }
       ]
     }


### PR DESCRIPTION
vitest allow to use `async` in `describe`'s callback.

This PR just remove `noAsyncDescribeCallback` error.

fix #511 