### PR TITLE
fix(valid-expect): allow `expect(value, "message")`

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -74,6 +74,8 @@ This rule triggers a warning if `expect` is called with no argument or with more
 	// ✅ good
 	expect(1).toBe(1)
 	expect(1, "expect value to be one").toBe(1)
+    const message = "expect value to be one"
+	expect(1, `Error Message: ${message}`).toBe(1)
 
 
 	// ❌ bad

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -68,13 +68,14 @@ This rule triggers a warning if `expect` is called with no argument or with more
   - Default: `1`
 
   - Enforce `expect` to be called with at most `maxArgs` arguments.
+  - Exception: `expect(value, "message")` is allowed.
 
 	```js
 	// ✅ good
 	expect(1).toBe(1)
+	expect(1, "expect value is one").toBe(1)
 
 
 	// ❌ bad
 	expect(1, 2, 3, 4).toBe(1)
 	```
-

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -73,7 +73,7 @@ This rule triggers a warning if `expect` is called with no argument or with more
 	```js
 	// ✅ good
 	expect(1).toBe(1)
-	expect(1, "expect value is one").toBe(1)
+	expect(1, "expect value to be one").toBe(1)
 
 
 	// ❌ bad

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -241,12 +241,17 @@ export default createEslintRule<[
         }
 
         if (expect.arguments.length > maxArgs) {
-          // if expect(value, "message"), it is valid usage
-          // Note: 2nd argument should be string literal, not a variable in current implementation
-          if (expect.arguments.length === 2
-            && expect.arguments[1].type === AST_NODE_TYPES.Literal
-            && typeof expect.arguments[1].value === 'string') {
-            return
+          // if expect(value, "message") and expect(value, `${message}`), it is valid usage
+          // Note: 2nd argument should be string, not a variable in current implementation
+          if (expect.arguments.length === 2) {
+            //  expect(value, "string literal")
+            const isSecondArgString = expect.arguments[1].type === AST_NODE_TYPES.Literal &&
+              typeof expect.arguments[1].value === 'string';
+            // expect(value, `template literal`)
+            const isSecondArgTemplateLiteral = expect.arguments[1].type === AST_NODE_TYPES.TemplateLiteral;
+            if (isSecondArgString || isSecondArgTemplateLiteral) {
+              return;
+            }
           }
 
           const { start } = expect.arguments[maxArgs].loc

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -241,6 +241,14 @@ export default createEslintRule<[
         }
 
         if (expect.arguments.length > maxArgs) {
+          // if expect(value, "message"), it is valid usage
+          // Note: 2nd argument should be string literal, not a variable in current implementation
+          if (expect.arguments.length === 2
+            && expect.arguments[1].type === AST_NODE_TYPES.Literal
+            && typeof expect.arguments[1].value === 'string') {
+            return
+          }
+
           const { start } = expect.arguments[maxArgs].loc
           const { end } = expect.arguments[expect.arguments.length - 1].loc
 

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -83,6 +83,7 @@ ruleTester.run(RULE_NAME, rule, {
       }
     });
      `,
+    'expect(value, "message").toBe(1);',
     {
       code: 'expect(1).toBe(2);',
       options: [{ maxArgs: 2 }]
@@ -143,20 +144,6 @@ ruleTester.run(RULE_NAME, rule, {
           endColumn: 8,
           column: 7,
           messageId: 'notEnoughArgs',
-          data: {
-            s: '',
-            amount: 1
-          }
-        }
-      ]
-    },
-    {
-      code: 'expect("something", "else").toEqual("something");',
-      errors: [
-        {
-          endColumn: 28,
-          column: 21,
-          messageId: 'tooManyArgs',
           data: {
             s: '',
             amount: 1
@@ -236,17 +223,60 @@ ruleTester.run(RULE_NAME, rule, {
             s: 's',
             amount: 3
           }
-        },
-        {
-          endColumn: 28,
-          column: 21,
-          messageId: 'tooManyArgs',
-          data: {
-            s: '',
-            amount: 1
-          }
         }
       ]
+    },
+    // expect() 2nd argument to be a string literal
+    {
+      code: 'expect("something", true).toEqual("something");',
+      errors: [
+        {
+          endColumn: 26,
+          column: 21,
+          messageId: 'tooManyArgs',
+        }
+      ]
+    },
+    {
+      code: 'expect("something", 12).toEqual("something");',
+      errors: [
+        {
+          endColumn: 24,
+          column: 21,
+          messageId: 'tooManyArgs',
+        }
+      ]
+    },
+    {
+      code: 'expect("something", {}).toEqual("something");',
+      errors: [
+        {
+          endColumn: 24,
+          column: 21,
+          messageId: 'tooManyArgs',
+        }
+      ]
+    },
+    {
+      code: 'expect("something", []).toEqual("something");',
+      errors: [
+        {
+          endColumn: 24,
+          column: 21,
+          messageId: 'tooManyArgs',
+        }
+      ]
+    },
+    // expect(value, "string literal") is valid, but expect(value, variable) is not
+    // because the AST does not have type information for variables
+    {
+      code: `const message = "message";
+      expect(1, message).toBe(2);`,
+      errors: [{
+        endColumn: 25,
+        column: 17,
+        messageId: 'tooManyArgs'
+      }]
     },
     {
       code: 'expect("something");',

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -84,6 +84,8 @@ ruleTester.run(RULE_NAME, rule, {
     });
      `,
     'expect(value, "message").toBe(1);',
+    'expect(value, `message`).toBe(1);',
+    'const message = "message"; expect(value, `${message}`).toBe(1);',
     {
       code: 'expect(1).toBe(2);',
       options: [{ maxArgs: 2 }]


### PR DESCRIPTION
Allow to use `expect(value, "message").toBe(1)` pattern.

📝 Note: TypeScript type information is required for accurate implementation.
Since ASTs may not contain type, only simple string literals and template literals are supported.

OK:

```js
expect(value, "string literal").toBe(1);
expect(value, `template literal`).toBe(1);

const message = "message";
expect(value, `${message}`).toBe(1);
```

NG:


```js
// variable is not allowed - it is limitation of current implemtation
const message = "message";
expect(value, message).toBe(1);
// non string types
expect(value, {}).toBe(1);
expect(value, []).toBe(1);
expect(value, 1).toBe(1);
```

## Note

This feature is undocument yet, but `vitest` type definition define it.

- https://github.com/vitest-dev/vitest/issues/6337

Waiting until it is documented may be the right thing to do.

fix https://github.com/vitest-dev/eslint-plugin-vitest/issues/503