### PR TITLE
fix: fix formatting rules name

### DIFF
--- a/src/rules/padding-around-after-all-blocks.ts
+++ b/src/rules/padding-around-after-all-blocks.ts
@@ -1,7 +1,6 @@
-import { getFilename } from "../utils/msc"
 import { Config, PaddingType, StatementType, createPaddingRule } from "../utils/padding"
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-after-all-blocks'
 
 export const config: Config[] = [
   {

--- a/src/rules/padding-around-after-each-blocks.ts
+++ b/src/rules/padding-around-after-each-blocks.ts
@@ -1,7 +1,6 @@
 import { Config, PaddingType, StatementType, createPaddingRule } from "../utils/padding";
-import { getFilename } from "../utils/msc";
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-after-each-blocks'
 
 export const config: Config[] = [
   {

--- a/src/rules/padding-around-all.ts
+++ b/src/rules/padding-around-all.ts
@@ -7,9 +7,8 @@ import { config as paddingAroundDescribeBlocksConfig } from './padding-around-de
 import { config as paddingAroundExpectGroupsConfig } from './padding-around-expect-groups';
 import { config as paddingAroundTestBlocksConfig } from './padding-around-test-blocks';
 import { createPaddingRule } from '../utils/padding';
-import { getFilename } from '../utils/msc';
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-all'
 
 export default createPaddingRule(
   RULE_NAME,

--- a/src/rules/padding-around-before-all-blocks.ts
+++ b/src/rules/padding-around-before-all-blocks.ts
@@ -1,7 +1,6 @@
-import { getFilename } from "../utils/msc";
 import { Config, PaddingType, StatementType, createPaddingRule } from "../utils/padding";
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-before-all-blocks'
 
 export const config: Config[] = [
   {

--- a/src/rules/padding-around-before-each-blocks.ts
+++ b/src/rules/padding-around-before-each-blocks.ts
@@ -1,7 +1,6 @@
-import { getFilename } from '../utils/msc';
 import { PaddingType, StatementType, createPaddingRule } from '../utils/padding';
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-before-each-blocks'
 
 export const config = [
   {

--- a/src/rules/padding-around-describe-blocks.ts
+++ b/src/rules/padding-around-describe-blocks.ts
@@ -1,7 +1,6 @@
-import { getFilename } from '../utils/msc';
 import { Config, PaddingType, StatementType, createPaddingRule } from '../utils/padding';
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-describe-blocks'
 
 export const config: Config[] = [
   {

--- a/src/rules/padding-around-expect-groups.ts
+++ b/src/rules/padding-around-expect-groups.ts
@@ -1,7 +1,6 @@
-import { getFilename } from "../utils/msc";
 import { Config, PaddingType, StatementType, createPaddingRule } from "../utils/padding";
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-expect-groups'
 
 export const config: Config[] = [
   {

--- a/src/rules/padding-around-test-blocks.ts
+++ b/src/rules/padding-around-test-blocks.ts
@@ -1,7 +1,6 @@
-import { getFilename } from '../utils/msc';
 import { PaddingType, StatementType, createPaddingRule } from '../utils/padding';
 
-export const RULE_NAME = getFilename(import.meta.url)
+export const RULE_NAME = 'padding-around-test-blocks'
 
 export const config = [
   {

--- a/src/utils/msc.ts
+++ b/src/utils/msc.ts
@@ -45,8 +45,3 @@ export interface CallExpressionWithSingleArgument<
 export const hasOnlyOneArgument = (
   call: TSESTree.CallExpression
 ): call is CallExpressionWithSingleArgument => call.arguments.length === 1
-
-
-export function getFilename(url: string) {
-  return parse(basename(fileURLToPath(url))).name
-}


### PR DESCRIPTION
Previously, `dist/*` can not define correct `RULE_NAME` in some rules.

This PR use hard code `RULE_NAME` instead of `getFilename` util

1. replace `getFilename` with `<filename>`
2. remove `getFilename` usage

```bash
#!/bin/bash

for file in $(ls -1 src/rules/*.ts); do
  echo "Processing $file"
  sed -i '' -e "s#getFilename(import.meta.url)#'$(basename ${file%.*})'#g" $file
done
```

fix #509 