### PR TITLE
fix: correct the message when required to be all lowercase

### DIFF
--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -54,7 +54,8 @@ export default createEslintRule<[
     },
     fixable: 'code',
     messages: {
-      lowerCaseTitle: '`{{ method }}`s should begin with lowercase'
+      lowerCaseTitle: '`{{ method }}`s should begin with lowercase',
+      fullyLowerCaseTitle: '`{{ method }}`s should be fully lowercase'
     },
     schema: [
       {
@@ -130,7 +131,7 @@ export default createEslintRule<[
         ) return
 
         context.report({
-          messageId: 'lowerCaseTitle',
+          messageId: lowercaseFirstCharacterOnly ? 'lowerCaseTitle' : 'fullyLowerCaseTitle',
           node: node.arguments[0],
           data: {
             method: vitestFnCall.name

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -55,7 +55,7 @@ export default createEslintRule<[
     fixable: 'code',
     messages: {
       lowerCaseTitle: '`{{ method }}`s should begin with lowercase',
-      fullyLowerCaseTitle: '`{{ method }}`s should be fully lowercase'
+      fullyLowerCaseTitle: '`{{ method }}`s should be lowercase'
     },
     schema: [
       {


### PR DESCRIPTION
When `lowercaseFirstCharacterOnly` is turned off, the error message needs to be changed.

By the way, I think changing this option to ‘fullyLowercaseCharacter’ might be more intuitive. Users set this value because they want all lowercase characters.