### PR TITLE
fix: fix typecheck

### DIFF
--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -4,7 +4,7 @@ import { isTypeOfVitestFnCall, parseVitestFnCall } from '../utils/parse-vitest-f
 import { CallExpressionWithSingleArgument, DescribeAlias, TestCaseName } from '../utils/types'
 
 export const RULE_NAME = 'prefer-lowercase-title'
-export type MessageIds = 'lowerCaseTitle'
+export type MessageIds = 'lowerCaseTitle' | 'fullyLowerCaseTitle'
 
 type IgnorableFunctionExpressions =
   | TestCaseName.it

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,7 +17,7 @@ interface PluginDocs {
   requiresTypeChecking?: boolean
 }
 
-export function createEslintRule<TOptions extends readonly unknown[], TMessageIds extends string>(rule: Readonly<ESLintUtils.RuleWithMetaAndName<TOptions, TMessageIds>>) {
+export function createEslintRule<TOptions extends readonly unknown[], TMessageIds extends string>(rule: Readonly<ESLintUtils.RuleWithMetaAndName<TOptions, TMessageIds, PluginDocs>>) {
   const createRule = ESLintUtils.RuleCreator<PluginDocs>(
     ruleName =>
       `https://github.com/veritem/eslint-plugin-vitest/blob/main/docs/rules/${ruleName}.md`


### PR DESCRIPTION
This PR adds:
- missing `MessageIds` for rule `prefer-lowercase-title`
- missing generic type `PluginDoc` for utils `createEslintRule`.

So now `npm run tsc` won't throw.