### PR TITLE
fix: add 'assertType' to 'expect-expect' allowed assertions

### DIFF
--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -65,7 +65,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     const unchecked: TSESTree.CallExpression[] = []
     const settings = parsePluginSettings(context.settings)
 
-    if (settings.typecheck) assertFunctionNames.push('expectTypeOf')
+    if (settings.typecheck) assertFunctionNames.push('expectTypeOf', 'assertType')
 
     function checkCallExpression(nodes: TSESTree.Node[]) {
       for (const node of nodes) {

--- a/tests/expect-expect.test.ts
+++ b/tests/expect-expect.test.ts
@@ -187,8 +187,21 @@ const it = base.extend<{
     },
     {
       code: `
-    it("should fail without 'typecheck' enabled", () => {
+    it("should fail 'expectTypeOf' without 'typecheck' enabled", () => {
      expectTypeOf({ a: 1 }).toEqualTypeOf<{ a: number }>()
+    });
+    `,
+      errors: [
+        {
+          messageId: 'noAssertions',
+          type: AST_NODE_TYPES.Identifier
+        }
+      ]
+    },
+    {
+      code: `
+    it("should fail 'assertType' without 'typecheck' enabled", () => {
+     assertType<string>('a')
     });
     `,
       errors: [


### PR DESCRIPTION
Also push `assertType` to the allowed `assertFunctionNames` in `expect-expect` rule when typecheck is enabled in the settings. 

fix #533.
