### PR TITLE
fix: Make `vitest` peer dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
 	"peerDependenciesMeta": {
 		"typescript": {
 			"optional": true
+		},
+		"vitest": {
+			"optional": true
 		}
 	},
 	"packageManager": "pnpm@9.7.0"


### PR DESCRIPTION
This makes this plugin easier to consume when it's installed as part of a shared config, in case `vitest` is not installed by the host.

See also: https://github.com/jest-community/eslint-plugin-jest/pull/970