### PR TITLE
Wrong JSON schema for expect-expect

### DIFF
--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -46,7 +46,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
         properties: {
           assertFunctionNames: {
             type: 'array',
-            items: [{ type: 'string' }]
+            items: { type: 'string' }
           },
           additionalTestBlockFunctions: {
             type: 'array',


### PR DESCRIPTION
`items: [{ type: 'string' }]` is not a valid JSON schema option.