### PR TITLE
fix: __filename is not defined in ES module scope when using eslint.config.mjs

### DIFF
--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -344,7 +344,7 @@ export default createEslintRule<[
     maxArgs: number
   }>
 ], MESSAGE_IDS>({
-  name: __filename,
+  name: RULE_NAME,
   meta: {
     docs: {
       description:


### PR DESCRIPTION
Oversight from #569 

Oops!