### PR TITLE
fix: `valid-title` false positives when `test.extend` is used

### DIFF
--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -197,6 +197,15 @@ export default createEslintRule<Options, MESSAGE_IDS>({
 
         if (vitestFnCall?.type !== 'describe' && vitestFnCall?.type !== 'test' && vitestFnCall?.type !== 'it') return
 
+        if (
+          vitestFnCall.members &&
+          vitestFnCall.members[0] &&
+          vitestFnCall.members[0].type === AST_NODE_TYPES.Identifier &&
+          vitestFnCall.members[0].name === 'extend'
+        ) {
+          return
+        }
+
         // check if extend keyword have been used
         if (vitestFnCall.members.some(m => m.type == AST_NODE_TYPES.Identifier && m.name == 'extend')) return
 

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -197,6 +197,8 @@ export default createEslintRule<Options, MESSAGE_IDS>({
 
         if (vitestFnCall?.type !== 'describe' && vitestFnCall?.type !== 'test' && vitestFnCall?.type !== 'it') return
 
+
+        // check if extend keyword have been used
         if (
           vitestFnCall.members &&
           vitestFnCall.members[0] &&
@@ -205,9 +207,6 @@ export default createEslintRule<Options, MESSAGE_IDS>({
         ) {
           return
         }
-
-        // check if extend keyword have been used
-        if (vitestFnCall.members.some(m => m.type == AST_NODE_TYPES.Identifier && m.name == 'extend')) return
 
         const [argument] = node.arguments
 

--- a/tests/valid-title.test.ts
+++ b/tests/valid-title.test.ts
@@ -605,3 +605,31 @@ ruleTester.run(RULE_NAME, rule, {
     }
   ]
 })
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    {
+      code: 'const localTest = test.extend({})',
+      name: 'does not error when using test.extend'
+    },
+    {
+      code: `import { it } from 'vitest'
+
+const test = it.extend({
+  fixture: [
+    async ({}, use) => {
+      setup()
+      await use()
+      teardown()
+    },
+    { auto: true }
+  ],
+})
+
+test('', () => {})`,
+      name: 'does not error when using it.extend'
+    }
+  ],
+
+  invalid: []
+})


### PR DESCRIPTION
## **This PR**:

- [X] Fixes `valid-title` false positives when `test.extend` is used.
- [X] Resolves #281.
- [X] Resolves #495.