### PR TITLE
[prefer-expect-assertions]fix false negatives for test context usage

### DIFF
--- a/src/utils/parse-vitest-fn-call.ts
+++ b/src/utils/parse-vitest-fn-call.ts
@@ -252,7 +252,7 @@ const parseVitestFnCallWithReasonInner = (
 
   const links = [name, ...rest.map(getAccessorValue)]
 
-  if (name !== 'vi' && name !== 'expect' && name !== 'expectTypeOf' && !ValidVitestFnCallChains.has(links.join('.')))
+  if (resolved.type !== "testContext" && name !== 'vi' && name !== 'expect' && name !== 'expectTypeOf' && !ValidVitestFnCallChains.has(links.join('.')))
     return null
 
   const parsedVitestFnCall: Omit<ParsedVitestFnCall, 'type'> = {
@@ -381,6 +381,10 @@ export const resolveScope = (
         if (key?.name === identifier)
           return "testContext"
       }
+
+      const namedParam = isFunction(def.node) ? def.node.params.find(params => params.type === AST_NODE_TYPES.Identifier ) : undefined
+      if (namedParam)
+        return "testContext"
 
       const importDetails = describePossibleImportDef(def)
 

--- a/tests/prefer-expect-assertions.test.ts
+++ b/tests/prefer-expect-assertions.test.ts
@@ -105,6 +105,47 @@ it('my test description', ({ expect }) => {expect.assertions();
       ],
     },
     {
+      code: `
+it('my test description', (context) => {
+  const a = 1;
+  const b = 2;
+
+  context.expect(sum(a, b)).toBe(a + b);
+})
+`,
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 2,
+          suggestions: [
+            {
+              messageId: 'suggestAddingHasAssertions',
+              output: `
+it('my test description', (context) => {context.expect.hasAssertions();
+  const a = 1;
+  const b = 2;
+
+  context.expect(sum(a, b)).toBe(a + b);
+})
+`
+            },
+            {
+              messageId: 'suggestAddingAssertions',
+              output: `
+it('my test description', (context) => {context.expect.assertions();
+  const a = 1;
+  const b = 2;
+
+  context.expect(sum(a, b)).toBe(a + b);
+})
+`
+            }
+          ]
+        }
+      ],
+    },
+    {
       code: 'it(\'resolves\', () => expect(staged()).toBe(true));',
       errors: [
         {


### PR DESCRIPTION
I included an additional fix for a similar false negative in another case of #567.