### PR TITLE
Refactor tsconfig for Stricter Type-Safe Settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,6 @@ import paddingAroundDescribeBlocks, { RULE_NAME as paddingAroundDescribeBlocksNa
 import paddingAroundExpectGroups, { RULE_NAME as paddingAroundExpectGroupsName } from './rules/padding-around-expect-groups'
 import paddingAroundTestBlocks, { RULE_NAME as paddingAroundTestBlocksName } from './rules/padding-around-test-blocks'
 import validExpectInPromise, { RULE_NAME as validExpectInPromiseName } from './rules/valid-expect-in-promise'
-import { TSESLint } from '@typescript-eslint/utils'
 
 const createConfig = <R extends Linter.RulesRecord>(rules: R) => (
   Object.keys(rules).reduce((acc, ruleName) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,78 +160,117 @@ const recommended = {
   [noImportNodeTestName]: 'error'
 } as const
 
-const rules = {
-  [lowerCaseTitleName]: lowerCaseTitle,
-  [maxNestedDescribeName]: maxNestedDescribe,
-  [noIdenticalTitleName]: noIdenticalTitle,
-  [noFocusedTestsName]: noFocusedTests,
-  [noConditionalTests]: noConditionalTest,
-  [expectedExpect]: expectExpect,
-  [useConsistentTestIt]: consistentTestIt,
-  [usePreferToBe]: preferToBe,
-  [noHooksName]: noHooks,
-  [noRestrictedViMethodsName]: noRestrictedViMethods,
-  [useConsistentTestFilename]: consistentTestFilename,
-  [maxExpectName]: maxExpect,
-  [noAliasMethodName]: noAliasMethod,
-  [noCommentedOutTestsName]: noCommentedOutTests,
-  [noConditionalExpectName]: noConditionalExpect,
-  [noConditionalInTestName]: noConditionalInTest,
-  [noDisabledTestsName]: noDisabledTests,
-  [noDoneCallbackName]: noDoneCallback,
-  [noDuplicateHooksName]: noDuplicateHooks,
-  [noLargeSnapShotsName]: noLargeSnapshots,
-  [noInterpolationInSnapshotsName]: nonInterpolationInSnapShots,
-  [noMocksImportName]: noMocksImport,
-  [noRestrictedMatchersName]: noRestrictedMatchers,
-  [noStandaloneExpectName]: noStandaloneExpect,
-  [noTestPrefixesName]: noTestPrefixes,
-  [noTestReturnStatementName]: noTestReturnStatement,
-  [noImportNodeTestName]: noImportNodeTest,
-  [preferCalledWithName]: preferCalledWith,
-  [validTitleName]: validTitle,
-  [validExpectName]: validExpect,
-  [preferToBeFalsyName]: preferToBeFalsy,
-  [preferToBeObjectName]: preferToBeObject,
-  [preferToBeTruthyName]: preferToBeTruthy,
-  [preferToHaveLengthName]: preferToHaveLength,
-  [preferEqualityMatcherName]: preferEqualityMatcher,
-  [preferStrictEqualName]: preferStrictEqual,
-  [preferExpectResolvesName]: preferExpectResolves,
-  [preferEachName]: preferEach,
-  [preferHooksOnTopName]: preferHooksOnTop,
-  [preferHooksInOrderName]: preferHooksInOrder,
-  [requireLocalTestContextForConcurrentSnapshotsName]: requireLocalTestContextForConcurrentSnapshots,
-  [preferMockPromiseShortHandName]: preferMockPromiseShorthand,
-  [preferViMockedName]: preferViMocked,
-  [preferSnapshotHintName]: preferSnapshotHint,
-  [validDescribeCallbackName]: validDescribeCallback,
-  [requireTopLevelDescribeName]: requireTopLevelDescribe,
-  [requireToThrowMessageName]: requireToThrowMessage,
-  [requireHookName]: requireHook,
-  [preferTodoName]: preferTodo,
-  [preferSpyOnName]: preferSpyOn,
-  [preferComparisonMatcherName]: preferComparisonMatcher,
-  [preferToContainName]: preferToContain,
-  [preferExpectAssertionsName]: preferExpectAssertions,
-  [paddingAroundAfterAllBlocksName]: paddingAroundAfterAllBlocks,
-  [paddingAroundAfterEachBlocksName]: paddingAroundAfterEachBlocks,
-  [paddingAroundAllName]: paddingAroundAll,
-  [paddingAroundBeforeAllBlocksName]: paddingAroundBeforeAllBlocks,
-  [paddingAroundBeforeEachBlocksName]: paddingAroundBeforeEachBlocks,
-  [paddingAroundDescribeBlocksName]: paddingAroundDescribeBlocks,
-  [paddingAroundExpectGroupsName]: paddingAroundExpectGroups,
-  [paddingAroundTestBlocksName]: paddingAroundTestBlocks,
-  [validExpectInPromiseName]: validExpectInPromise
-}
-
 const plugin = {
   meta: {
     name: 'vitest',
     version
   },
-  rules,
-  configs: { } as Record<string, TSESLint.Linter.ConfigType>,
+  rules: {
+    [lowerCaseTitleName]: lowerCaseTitle,
+    [maxNestedDescribeName]: maxNestedDescribe,
+    [noIdenticalTitleName]: noIdenticalTitle,
+    [noFocusedTestsName]: noFocusedTests,
+    [noConditionalTests]: noConditionalTest,
+    [expectedExpect]: expectExpect,
+    [useConsistentTestIt]: consistentTestIt,
+    [usePreferToBe]: preferToBe,
+    [noHooksName]: noHooks,
+    [noRestrictedViMethodsName]: noRestrictedViMethods,
+    [useConsistentTestFilename]: consistentTestFilename,
+    [maxExpectName]: maxExpect,
+    [noAliasMethodName]: noAliasMethod,
+    [noCommentedOutTestsName]: noCommentedOutTests,
+    [noConditionalExpectName]: noConditionalExpect,
+    [noConditionalInTestName]: noConditionalInTest,
+    [noDisabledTestsName]: noDisabledTests,
+    [noDoneCallbackName]: noDoneCallback,
+    [noDuplicateHooksName]: noDuplicateHooks,
+    [noLargeSnapShotsName]: noLargeSnapshots,
+    [noInterpolationInSnapshotsName]: nonInterpolationInSnapShots,
+    [noMocksImportName]: noMocksImport,
+    [noRestrictedMatchersName]: noRestrictedMatchers,
+    [noStandaloneExpectName]: noStandaloneExpect,
+    [noTestPrefixesName]: noTestPrefixes,
+    [noTestReturnStatementName]: noTestReturnStatement,
+    [noImportNodeTestName]: noImportNodeTest,
+    [preferCalledWithName]: preferCalledWith,
+    [validTitleName]: validTitle,
+    [validExpectName]: validExpect,
+    [preferToBeFalsyName]: preferToBeFalsy,
+    [preferToBeObjectName]: preferToBeObject,
+    [preferToBeTruthyName]: preferToBeTruthy,
+    [preferToHaveLengthName]: preferToHaveLength,
+    [preferEqualityMatcherName]: preferEqualityMatcher,
+    [preferStrictEqualName]: preferStrictEqual,
+    [preferExpectResolvesName]: preferExpectResolves,
+    [preferEachName]: preferEach,
+    [preferHooksOnTopName]: preferHooksOnTop,
+    [preferHooksInOrderName]: preferHooksInOrder,
+    [requireLocalTestContextForConcurrentSnapshotsName]: requireLocalTestContextForConcurrentSnapshots,
+    [preferMockPromiseShortHandName]: preferMockPromiseShorthand,
+    [preferViMockedName]: preferViMocked,
+    [preferSnapshotHintName]: preferSnapshotHint,
+    [validDescribeCallbackName]: validDescribeCallback,
+    [requireTopLevelDescribeName]: requireTopLevelDescribe,
+    [requireToThrowMessageName]: requireToThrowMessage,
+    [requireHookName]: requireHook,
+    [preferTodoName]: preferTodo,
+    [preferSpyOnName]: preferSpyOn,
+    [preferComparisonMatcherName]: preferComparisonMatcher,
+    [preferToContainName]: preferToContain,
+    [preferExpectAssertionsName]: preferExpectAssertions,
+    [paddingAroundAfterAllBlocksName]: paddingAroundAfterAllBlocks,
+    [paddingAroundAfterEachBlocksName]: paddingAroundAfterEachBlocks,
+    [paddingAroundAllName]: paddingAroundAll,
+    [paddingAroundBeforeAllBlocksName]: paddingAroundBeforeAllBlocks,
+    [paddingAroundBeforeEachBlocksName]: paddingAroundBeforeEachBlocks,
+    [paddingAroundDescribeBlocksName]: paddingAroundDescribeBlocks,
+    [paddingAroundExpectGroupsName]: paddingAroundExpectGroups,
+    [paddingAroundTestBlocksName]: paddingAroundTestBlocks,
+    [validExpectInPromiseName]: validExpectInPromise
+  },
+  configs: {
+    'legacy-recommended': createConfigLegacy(recommended),
+    'legacy-all': createConfigLegacy(allRules),
+    'recommended': {
+      plugins: {
+        get vitest() {
+          return plugin
+        }
+      },
+      rules: createConfig(recommended)
+    },
+    'all': {
+      plugins: {
+        get vitest() {
+          return plugin
+        }
+      },
+      rules: createConfig(allRules)
+    },
+    'env': {
+      languageOptions: {
+        globals: {
+          suite: 'writable',
+          test: 'writable',
+          describe: 'writable',
+          it: 'writable',
+          expectTypeOf: 'writable',
+          assertType: 'writable',
+          expect: 'writable',
+          assert: 'writable',
+          vitest: 'writable',
+          vi: 'writable',
+          beforeAll: 'writable',
+          afterAll: 'writable',
+          beforeEach: 'writable',
+          afterEach: 'writable',
+          onTestFailed: 'writable',
+          onTestFinished: 'writable'
+        }
+      }
+    }
+  },
   environments: {
     env: {
       globals: {
@@ -251,35 +290,6 @@ const plugin = {
         afterEach: true,
         onTestFailed: true,
         onTestFinished: true
-      }
-    }
-  }
-}
-
-plugin.configs = {
-  'legacy-recommended': createConfigLegacy(recommended),
-  'legacy-all': createConfigLegacy(allRules),
-  'recommended': { plugins: { vitest: plugin }, rules: createConfig(recommended) },
-  'all': { plugins: { vitest: plugin }, rules: createConfig(allRules) },
-  'env': {
-    languageOptions: {
-      globals: {
-        suite: 'writable',
-        test: 'writable',
-        describe: 'writable',
-        it: 'writable',
-        expectTypeOf: 'writable',
-        assertType: 'writable',
-        expect: 'writable',
-        assert: 'writable',
-        vitest: 'writable',
-        vi: 'writable',
-        beforeAll: 'writable',
-        afterAll: 'writable',
-        beforeEach: 'writable',
-        afterEach: 'writable',
-        onTestFailed: 'writable',
-        onTestFinished: 'writable'
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { ESLint, Linter } from 'eslint'
+import type { Linter } from 'eslint'
 import { version } from '../package.json'
 import lowerCaseTitle, { RULE_NAME as lowerCaseTitleName } from './rules/prefer-lowercase-title'
 import maxNestedDescribe, { RULE_NAME as maxNestedDescribeName } from './rules/max-nested-describe'
@@ -62,6 +62,7 @@ import paddingAroundDescribeBlocks, { RULE_NAME as paddingAroundDescribeBlocksNa
 import paddingAroundExpectGroups, { RULE_NAME as paddingAroundExpectGroupsName } from './rules/padding-around-expect-groups'
 import paddingAroundTestBlocks, { RULE_NAME as paddingAroundTestBlocksName } from './rules/padding-around-test-blocks'
 import validExpectInPromise, { RULE_NAME as validExpectInPromiseName } from './rules/valid-expect-in-promise'
+import { TSESLint } from '@typescript-eslint/utils'
 
 const createConfig = <R extends Linter.RulesRecord>(rules: R) => (
   Object.keys(rules).reduce((acc, ruleName) => {
@@ -159,117 +160,78 @@ const recommended = {
   [noImportNodeTestName]: 'error'
 } as const
 
+const rules = {
+  [lowerCaseTitleName]: lowerCaseTitle,
+  [maxNestedDescribeName]: maxNestedDescribe,
+  [noIdenticalTitleName]: noIdenticalTitle,
+  [noFocusedTestsName]: noFocusedTests,
+  [noConditionalTests]: noConditionalTest,
+  [expectedExpect]: expectExpect,
+  [useConsistentTestIt]: consistentTestIt,
+  [usePreferToBe]: preferToBe,
+  [noHooksName]: noHooks,
+  [noRestrictedViMethodsName]: noRestrictedViMethods,
+  [useConsistentTestFilename]: consistentTestFilename,
+  [maxExpectName]: maxExpect,
+  [noAliasMethodName]: noAliasMethod,
+  [noCommentedOutTestsName]: noCommentedOutTests,
+  [noConditionalExpectName]: noConditionalExpect,
+  [noConditionalInTestName]: noConditionalInTest,
+  [noDisabledTestsName]: noDisabledTests,
+  [noDoneCallbackName]: noDoneCallback,
+  [noDuplicateHooksName]: noDuplicateHooks,
+  [noLargeSnapShotsName]: noLargeSnapshots,
+  [noInterpolationInSnapshotsName]: nonInterpolationInSnapShots,
+  [noMocksImportName]: noMocksImport,
+  [noRestrictedMatchersName]: noRestrictedMatchers,
+  [noStandaloneExpectName]: noStandaloneExpect,
+  [noTestPrefixesName]: noTestPrefixes,
+  [noTestReturnStatementName]: noTestReturnStatement,
+  [noImportNodeTestName]: noImportNodeTest,
+  [preferCalledWithName]: preferCalledWith,
+  [validTitleName]: validTitle,
+  [validExpectName]: validExpect,
+  [preferToBeFalsyName]: preferToBeFalsy,
+  [preferToBeObjectName]: preferToBeObject,
+  [preferToBeTruthyName]: preferToBeTruthy,
+  [preferToHaveLengthName]: preferToHaveLength,
+  [preferEqualityMatcherName]: preferEqualityMatcher,
+  [preferStrictEqualName]: preferStrictEqual,
+  [preferExpectResolvesName]: preferExpectResolves,
+  [preferEachName]: preferEach,
+  [preferHooksOnTopName]: preferHooksOnTop,
+  [preferHooksInOrderName]: preferHooksInOrder,
+  [requireLocalTestContextForConcurrentSnapshotsName]: requireLocalTestContextForConcurrentSnapshots,
+  [preferMockPromiseShortHandName]: preferMockPromiseShorthand,
+  [preferViMockedName]: preferViMocked,
+  [preferSnapshotHintName]: preferSnapshotHint,
+  [validDescribeCallbackName]: validDescribeCallback,
+  [requireTopLevelDescribeName]: requireTopLevelDescribe,
+  [requireToThrowMessageName]: requireToThrowMessage,
+  [requireHookName]: requireHook,
+  [preferTodoName]: preferTodo,
+  [preferSpyOnName]: preferSpyOn,
+  [preferComparisonMatcherName]: preferComparisonMatcher,
+  [preferToContainName]: preferToContain,
+  [preferExpectAssertionsName]: preferExpectAssertions,
+  [paddingAroundAfterAllBlocksName]: paddingAroundAfterAllBlocks,
+  [paddingAroundAfterEachBlocksName]: paddingAroundAfterEachBlocks,
+  [paddingAroundAllName]: paddingAroundAll,
+  [paddingAroundBeforeAllBlocksName]: paddingAroundBeforeAllBlocks,
+  [paddingAroundBeforeEachBlocksName]: paddingAroundBeforeEachBlocks,
+  [paddingAroundDescribeBlocksName]: paddingAroundDescribeBlocks,
+  [paddingAroundExpectGroupsName]: paddingAroundExpectGroups,
+  [paddingAroundTestBlocksName]: paddingAroundTestBlocks,
+  [validExpectInPromiseName]: validExpectInPromise
+}
+
 const plugin = {
   meta: {
     name: 'vitest',
     version
   },
-  rules: {
-    [lowerCaseTitleName]: lowerCaseTitle,
-    [maxNestedDescribeName]: maxNestedDescribe,
-    [noIdenticalTitleName]: noIdenticalTitle,
-    [noFocusedTestsName]: noFocusedTests,
-    [noConditionalTests]: noConditionalTest,
-    [expectedExpect]: expectExpect,
-    [useConsistentTestIt]: consistentTestIt,
-    [usePreferToBe]: preferToBe,
-    [noHooksName]: noHooks,
-    [noRestrictedViMethodsName]: noRestrictedViMethods,
-    [useConsistentTestFilename]: consistentTestFilename,
-    [maxExpectName]: maxExpect,
-    [noAliasMethodName]: noAliasMethod,
-    [noCommentedOutTestsName]: noCommentedOutTests,
-    [noConditionalExpectName]: noConditionalExpect,
-    [noConditionalInTestName]: noConditionalInTest,
-    [noDisabledTestsName]: noDisabledTests,
-    [noDoneCallbackName]: noDoneCallback,
-    [noDuplicateHooksName]: noDuplicateHooks,
-    [noLargeSnapShotsName]: noLargeSnapshots,
-    [noInterpolationInSnapshotsName]: nonInterpolationInSnapShots,
-    [noMocksImportName]: noMocksImport,
-    [noRestrictedMatchersName]: noRestrictedMatchers,
-    [noStandaloneExpectName]: noStandaloneExpect,
-    [noTestPrefixesName]: noTestPrefixes,
-    [noTestReturnStatementName]: noTestReturnStatement,
-    [noImportNodeTestName]: noImportNodeTest,
-    [preferCalledWithName]: preferCalledWith,
-    [validTitleName]: validTitle,
-    [validExpectName]: validExpect,
-    [preferToBeFalsyName]: preferToBeFalsy,
-    [preferToBeObjectName]: preferToBeObject,
-    [preferToBeTruthyName]: preferToBeTruthy,
-    [preferToHaveLengthName]: preferToHaveLength,
-    [preferEqualityMatcherName]: preferEqualityMatcher,
-    [preferStrictEqualName]: preferStrictEqual,
-    [preferExpectResolvesName]: preferExpectResolves,
-    [preferEachName]: preferEach,
-    [preferHooksOnTopName]: preferHooksOnTop,
-    [preferHooksInOrderName]: preferHooksInOrder,
-    [requireLocalTestContextForConcurrentSnapshotsName]: requireLocalTestContextForConcurrentSnapshots,
-    [preferMockPromiseShortHandName]: preferMockPromiseShorthand,
-    [preferViMockedName]: preferViMocked,
-    [preferSnapshotHintName]: preferSnapshotHint,
-    [validDescribeCallbackName]: validDescribeCallback,
-    [requireTopLevelDescribeName]: requireTopLevelDescribe,
-    [requireToThrowMessageName]: requireToThrowMessage,
-    [requireHookName]: requireHook,
-    [preferTodoName]: preferTodo,
-    [preferSpyOnName]: preferSpyOn,
-    [preferComparisonMatcherName]: preferComparisonMatcher,
-    [preferToContainName]: preferToContain,
-    [preferExpectAssertionsName]: preferExpectAssertions,
-    [paddingAroundAfterAllBlocksName]: paddingAroundAfterAllBlocks,
-    [paddingAroundAfterEachBlocksName]: paddingAroundAfterEachBlocks,
-    [paddingAroundAllName]: paddingAroundAll,
-    [paddingAroundBeforeAllBlocksName]: paddingAroundBeforeAllBlocks,
-    [paddingAroundBeforeEachBlocksName]: paddingAroundBeforeEachBlocks,
-    [paddingAroundDescribeBlocksName]: paddingAroundDescribeBlocks,
-    [paddingAroundExpectGroupsName]: paddingAroundExpectGroups,
-    [paddingAroundTestBlocksName]: paddingAroundTestBlocks,
-    [validExpectInPromiseName]: validExpectInPromise
-  },
-  configs: {
-    'legacy-recommended': createConfigLegacy(recommended),
-    'legacy-all': createConfigLegacy(allRules),
-    'recommended': {
-      plugins: {
-        get vitest(): ESLint.Plugin {
-          return plugin
-        }
-      },
-      rules: createConfig(recommended)
-    },
-    'all': {
-      plugins: {
-        get vitest(): ESLint.Plugin {
-          return plugin
-        }
-      },
-      rules: createConfig(allRules)
-    },
-    'env': {
-      languageOptions: {
-        globals: {
-          suite: 'writable',
-          test: 'writable',
-          describe: 'writable',
-          it: 'writable',
-          expectTypeOf: 'writable',
-          assertType: 'writable',
-          expect: 'writable',
-          assert: 'writable',
-          vitest: 'writable',
-          vi: 'writable',
-          beforeAll: 'writable',
-          afterAll: 'writable',
-          beforeEach: 'writable',
-          afterEach: 'writable',
-          onTestFailed: 'writable',
-          onTestFinished: 'writable'
-        }
-      }
-    }
-  },
+  rules,
+  configs: { } as Record<string, TSESLint.Linter.ConfigType>,
   environments: {
     env: {
       globals: {
@@ -292,6 +254,35 @@ const plugin = {
       }
     }
   }
-} satisfies ESLint.Plugin
+}
+
+plugin.configs = {
+  'legacy-recommended': createConfigLegacy(recommended),
+  'legacy-all': createConfigLegacy(allRules),
+  'recommended': { plugins: { vitest: plugin }, rules: createConfig(recommended) },
+  'all': { plugins: { vitest: plugin }, rules: createConfig(allRules) },
+  'env': {
+    languageOptions: {
+      globals: {
+        suite: 'writable',
+        test: 'writable',
+        describe: 'writable',
+        it: 'writable',
+        expectTypeOf: 'writable',
+        assertType: 'writable',
+        expect: 'writable',
+        assert: 'writable',
+        vitest: 'writable',
+        vi: 'writable',
+        beforeAll: 'writable',
+        afterAll: 'writable',
+        beforeEach: 'writable',
+        afterEach: 'writable',
+        onTestFailed: 'writable',
+        onTestFinished: 'writable'
+      }
+    }
+  }
+}
 
 export default plugin

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,7 +10,6 @@ import {
   KnownMemberExpression,
   ParsedExpectVitestFnCall
 } from './parse-vitest-fn-call'
-import { Rule } from 'eslint'
 
 interface PluginDocs {
   recommended?: boolean
@@ -18,12 +17,12 @@ interface PluginDocs {
 }
 
 export function createEslintRule<TOptions extends readonly unknown[], TMessageIds extends string>(rule: Readonly<ESLintUtils.RuleWithMetaAndName<TOptions, TMessageIds, PluginDocs>>) {
-  const createRule = ESLintUtils.RuleCreator<PluginDocs>(
+  const createRule = ESLintUtils.RuleCreator(
     ruleName =>
       `https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/${ruleName}.md`
   )
 
-  return createRule(rule) as unknown as Rule.RuleModule
+  return createRule(rule)
 }
 
 export const joinNames = (a: string | null, b: string | null): string | null =>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,7 +17,7 @@ interface PluginDocs {
 }
 
 export function createEslintRule<TOptions extends readonly unknown[], TMessageIds extends string>(rule: Readonly<ESLintUtils.RuleWithMetaAndName<TOptions, TMessageIds, PluginDocs>>) {
-  const createRule = ESLintUtils.RuleCreator(
+  const createRule = ESLintUtils.RuleCreator<PluginDocs>(
     ruleName =>
       `https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/${ruleName}.md`
   )

--- a/tests/expect-expect.test.ts
+++ b/tests/expect-expect.test.ts
@@ -74,7 +74,7 @@ it('example', async () => {
     },
     {
       code: 'afterEach(() => {});',
-      options: [{ additionalTestBlockFunctions: ['afterEach'] }],
+      options: [{ additionalTestBlockFunctions: ['afterEach'], assertFunctionNames: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -88,7 +88,7 @@ it('example', async () => {
      const output = NumberToLongString(theory.input);
     })
     `,
-      options: [{ additionalTestBlockFunctions: ['theoretically'] }],
+      options: [{ additionalTestBlockFunctions: ['theoretically'], assertFunctionNames: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -107,7 +107,7 @@ it('example', async () => {
     },
     {
       code: 'test("should fail", () => { foo(true).toBe(true); })',
-      options: [{ assertFunctionNames: ['expect'] }],
+      options: [{ assertFunctionNames: ['expect'], additionalTestBlockFunctions: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -117,7 +117,7 @@ it('example', async () => {
     },
     {
       code: 'it("should also fail",() => expectSaga(mySaga).returns());',
-      options: [{ assertFunctionNames: ['expect'] }],
+      options: [{ assertFunctionNames: ['expect'], additionalTestBlockFunctions: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -127,7 +127,7 @@ it('example', async () => {
     },
     {
       code: 'test(\'should fail\', () => request.get().foo().expect(456));',
-      options: [{ assertFunctionNames: ['request.*.expect'] }],
+      options: [{ assertFunctionNames: ['request.*.expect'], additionalTestBlockFunctions: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -137,7 +137,7 @@ it('example', async () => {
     },
     {
       code: 'test(\'should fail\', () => request.get().foo().bar().expect(456));',
-      options: [{ assertFunctionNames: ['request.foo**.expect'] }],
+      options: [{ assertFunctionNames: ['request.foo**.expect'], additionalTestBlockFunctions: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -147,7 +147,7 @@ it('example', async () => {
     },
     {
       code: 'test(\'should fail\', () => tester.request(123));',
-      options: [{ assertFunctionNames: ['request.*'] }],
+      options: [{ assertFunctionNames: ['request.*'], additionalTestBlockFunctions: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -157,7 +157,7 @@ it('example', async () => {
     },
     {
       code: 'test(\'should fail\', () => request(123));',
-      options: [{ assertFunctionNames: ['request.*'] }],
+      options: [{ assertFunctionNames: ['request.*'], additionalTestBlockFunctions: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -167,7 +167,7 @@ it('example', async () => {
     },
     {
       code: 'test(\'should fail\', () => request(123));',
-      options: [{ assertFunctionNames: ['request.**'] }],
+      options: [{ assertFunctionNames: ['request.**'], additionalTestBlockFunctions: [] }],
       errors: [
         {
           messageId: 'noAssertions',
@@ -235,7 +235,7 @@ it('example', async () => {
        // ...
      })
        `,
-      options: [{ additionalTestBlockFunctions: ['myExtendedTest'] }],
+      options: [{ additionalTestBlockFunctions: ['myExtendedTest'], assertFunctionNames: [] }],
       languageOptions: { parserOptions: { sourceType: 'module' } },
       errors: [
         {

--- a/tests/unbound-method.test.ts
+++ b/tests/unbound-method.test.ts
@@ -5,11 +5,12 @@ import unboundMethod from '../src/rules/unbound-method'
 const rootPath = path.join(__dirname, './fixtures')
 
 const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    tsconfigRootDir: rootPath,
-    project: './tsconfig.json',
-    sourceType: 'module'
+  languageOptions: {
+    parserOptions: {
+      tsconfigRootDir: rootPath,
+      project: './tsconfig.json',
+      sourceType: 'module'
+    }
   }
 })
 
@@ -20,16 +21,16 @@ ruleTester.run('unbound-method', unboundMethod, {
    public logArrowBound = (): void => {
     console.log(bound);
    };
-  
+
    public logManualBind(): void {
     console.log(this);
    }
   }
-  
+
   const instance = new MyClass();
   const logArrowBound = instance.logArrowBound;
   const logManualBind = instance.logManualBind.bind(instance);
-  
+
   logArrowBound();
   logManualBind();`,
       skip: true
@@ -43,9 +44,9 @@ ruleTester.run('unbound-method', unboundMethod, {
    process.stdout.write(str);
     }
   }
-  
+
   const console = new Console();
-  
+
   Promise.resolve().then(console.log);
      `,
       skip: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true,
     "strictNullChecks": true
  },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts","tests/**/*.ts"],
 }


### PR DESCRIPTION
I have made the following changes:

- Fixed type errors in the test files.
- Updated `plugin.config`. Reference: [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest/blob/main/src/index.ts).

There may be some misunderstandings on my part, but I would appreciate your review.