### PR TITLE
fix: detect expectations in chains with underscores

### DIFF
--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -22,7 +22,7 @@ function matchesAssertFunctionName(
         .split('.')
         .map((x) => {
           if (x === '**')
-            return '[a-z\\d\\.]*'
+            return '[_a-z\\d\\.]*'
 
           return x.replace(/\*/gu, '[a-z\\d]*')
         })

--- a/tests/expect-expect.test.ts
+++ b/tests/expect-expect.test.ts
@@ -1,6 +1,7 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/utils'
-import rule, { RULE_NAME } from '../src/rules/expect-expect'
-import { ruleTester } from './ruleTester'
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import rule, { RULE_NAME } from '../src/rules/expect-expect';
+import { ruleTester } from './ruleTester';
 
 ruleTester.run(RULE_NAME, rule, {
   valid: [
@@ -42,7 +43,15 @@ it('example', async () => {
   const result = Promise.reject<string>('error');
 
   await expect(result.then((it) => it.toUpperCase())).rejects.toThrow();
-});`
+});`,
+  {
+    code: `it("should pass", () => { anyChain.of.calls.expect(true) })`,
+    options: [{ assertFunctionNames: ['**.expect'] }]
+  },
+  {
+    code: `it("should pass", () => { any_chain.of.calls.expect(true) })`,
+    options: [{ assertFunctionNames: ['**.expect'] }]
+  }
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes expectation detection in call chains when one member contains an underscore.

For instance

```
it('should pass', () => {
  any_chain.to.expect(true)
})
```

Does not currently pass, whereas the following does pass

```
it('should pass', () => {
  anyChain.to.expect(true)
})
```