### PR TITLE
fix: make rule message punctuation more consistent and address some typos

### DIFF
--- a/src/rules/consistent-test-filename.ts
+++ b/src/rules/consistent-test-filename.ts
@@ -24,7 +24,7 @@ export default createEslintRule<
       description: 'require .spec test file pattern'
     },
     messages: {
-      consistentTestFilename: 'use test file name pattern {{pattern}}'
+      consistentTestFilename: 'Use test file name pattern {{ pattern }}'
     },
     schema: [
       {

--- a/src/rules/max-expects.ts
+++ b/src/rules/max-expects.ts
@@ -19,7 +19,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
       description: 'enforce a maximum number of expect per test'
     },
     messages: {
-      maxExpect: 'Too many assertion calls ({{count}}). Maximum is {{max}}.'
+      maxExpect: 'Too many assertion calls ({{ count }}) - maximum allowed is {{ max }}'
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/max-nested-describe.ts
+++ b/src/rules/max-nested-describe.ts
@@ -31,7 +31,7 @@ export default createEslintRule<Options, MESSAGE_ID>({
     ],
     messages: {
       maxNestedDescribe:
-                'Nested describe block should be less than set max value.'
+                'Nested describe block should be less than set max value'
     }
   },
   defaultOptions: [

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -18,7 +18,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
       recommended: false
     },
     messages: {
-      noCommentedOutTests: 'Remove commented out tests. You may want to use `skip` or `only` instead.'
+      noCommentedOutTests: 'Remove commented out tests - you may want to use `skip` or `only` instead'
     },
     schema: [],
     type: 'suggestion'

--- a/src/rules/no-conditional-tests.ts
+++ b/src/rules/no-conditional-tests.ts
@@ -14,7 +14,7 @@ export default createEslintRule<[], MESSAGE_ID>({
     },
     schema: [],
     messages: {
-      noConditionalTests: 'Avoid using if conditions in a test.'
+      noConditionalTests: 'Avoid using if conditions in a test'
     }
   },
   defaultOptions: [],

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -18,8 +18,8 @@ export default createEslintRule<Options, MESSAGE_ID>({
       pending: 'Call to pending()',
       pendingSuite: 'Call to pending() within test suite',
       pendingTest: 'Call to pending() within test',
-      disabledSuite: 'Disabled test suite. If you want to skip a test suite temporarily, use .todo() instead.',
-      disabledTest: 'Disabled test. If you want to skip a test temporarily, use .todo() instead.'
+      disabledSuite: 'Disabled test suite - if you want to skip a test suite temporarily, use .todo() instead',
+      disabledTest: 'Disabled test - if you want to skip a test temporarily, use .todo() instead'
     },
     schema: []
   },

--- a/src/rules/no-duplicate-hooks.ts
+++ b/src/rules/no-duplicate-hooks.ts
@@ -14,7 +14,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
       requiresTypeChecking: false
     },
     messages: {
-      noDuplicateHooks: 'Duplicate {{hook}} in describe block.'
+      noDuplicateHooks: 'Duplicate {{ hook }} in describe block'
     },
     schema: [],
     type: 'suggestion'

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -39,7 +39,7 @@ export default createEslintRule<Options, MessageIds>({
       }
     ],
     messages: {
-      noFocusedTests: 'Focused tests are not allowed.'
+      noFocusedTests: 'Focused tests are not allowed'
     }
   },
   defaultOptions: [{ fixable: true }],

--- a/src/rules/no-mocks-import.ts
+++ b/src/rules/no-mocks-import.ts
@@ -21,7 +21,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
       recommended: false
     },
     messages: {
-      noMocksImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use \`vi.mock\` and import from the original module path.`
+      noMocksImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use \`vi.mock\` and import from the original module path`
     },
     schema: []
   },

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -15,7 +15,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
     },
     type: 'suggestion',
     messages: {
-      usePreferredName: 'Use "{{preferredNodeName}}" instead'
+      usePreferredName: 'Use "{{ preferredNodeName }}" instead'
     },
     fixable: 'code',
     schema: []

--- a/src/rules/prefer-to-be-object.ts
+++ b/src/rules/prefer-to-be-object.ts
@@ -17,7 +17,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
     },
     fixable: 'code',
     messages: {
-      preferToBeObject: 'Prefer toBeObject() to test if a value is an object.'
+      preferToBeObject: 'Prefer toBeObject() to test if a value is an object'
     },
     schema: []
   },

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -20,8 +20,8 @@ export default createEslintRule<Options, MESSAGE_IDS>({
     messages: {
       tooManyDescribes:
         'There should not be more than {{ max }} describe{{ s }} at the top level',
-      unexpectedTestCase: 'All test cases must be wrapped in a describe block.',
-      unexpectedHook: 'All hooks must be wrapped in a describe block.'
+      unexpectedTestCase: 'All test cases must be wrapped in a describe block',
+      unexpectedHook: 'All hooks must be wrapped in a describe block'
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -125,14 +125,14 @@ export default createEslintRule<[
       recommended: false
     },
     messages: {
-      tooManyArgs: 'Expect takes most {{ amount}} argument{{s}}',
-      notEnoughArgs: 'Expect requires atleast {{ amount }} argument{{s}}',
-      modifierUnknown: 'Expect has unknown modifier',
-      matcherNotFound: 'Expect must have a corresponding matcher call.',
-      matcherNotCalled: 'Matchers must be called to assert.',
-      asyncMustBeAwaited: 'Async assertions must be awaited{{orReturned}}',
+      tooManyArgs: 'Expect takes at most {{ amount}} argument{{ s }}',
+      notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
+      modifierUnknown: 'Expect has an unknown modifier',
+      matcherNotFound: 'Expect must have a corresponding matcher call',
+      matcherNotCalled: 'Matchers must be called to assert',
+      asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}',
       promisesWithAsyncAssertionsMustBeAwaited:
-        'Promises which return async assertions must be awaited{{orReturned}}'
+        'Promises which return async assertions must be awaited{{ orReturned }}'
     },
     type: 'suggestion',
     fixable: 'code',

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -128,14 +128,14 @@ export default createEslintRule<Options, MESSAGE_IDS>({
     },
     messages: {
       titleMustBeString: 'Test title must be a string, a function or class name',
-      emptyTitle: '{{functionName}} should not have an empty title',
+      emptyTitle: '{{ functionName }} should not have an empty title',
       duplicatePrefix: 'should not have duplicate prefix',
       accidentalSpace: 'should not have leading or trailing spaces',
-      disallowedWord: '"{{word}}" is not allowed in test title',
-      mustNotMatch: '{{functionName}} should not match {{pattern}}',
-      mustMatch: '{{functionName}} should match {{pattern}}',
-      mustNotMatchCustom: '{{message}}',
-      mustMatchCustom: '{{message}}'
+      disallowedWord: '"{{ word }}" is not allowed in test title',
+      mustNotMatch: '{{ functionName }} should not match {{ pattern }}',
+      mustMatch: '{{ functionName }} should match {{ pattern }}',
+      mustNotMatchCustom: '{{ message }}',
+      mustMatchCustom: '{{ message }}'
     },
     type: 'suggestion',
     schema: [


### PR DESCRIPTION
I noticed a spelling mistake in `valid-expect` that I'd fixed in `eslint-plugin-jest` which revealed https://github.com/jest-community/eslint-plugin-jest/pull/1444 has not been ported over, so this mostly does that though also has a few other adjustments.

There's some more improvements that could be made which I don't mind doing (namely around the use of code quotes), but didn't want to do too much without first confirming folks are happy with this kind of "format" 🙂 