### PR TITLE
chore: avoid nullish config type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,22 +159,23 @@ const recommended = {
   [noImportNodeTestName]: 'error'
 } as const
 
-interface VitestPLugin extends Linter.Plugin {
+interface VitestPlugin extends Linter.Plugin {
   meta: {
     name: string
     version: string
   }
   rules: Record<string, RuleModule<any, any>>
   // TODO: use classic type for config
-  configs?: Record<string, any>
+  configs: Record<string, any>
   environments?: Record<string, any>
 }
 
-const plugin: VitestPLugin = {
+const plugin: VitestPlugin = {
   meta: {
     name: 'vitest',
     version
   },
+  configs: {},
   rules: {
     [lowerCaseTitleName]: lowerCaseTitle,
     [maxNestedDescribeName]: maxNestedDescribe,


### PR DESCRIPTION
This PR changes the `VitestPlugin` type to use a non nullish `configs` value, as it makes the type easier to use in type aware configs.

![grafik](https://github.com/user-attachments/assets/f2bf46ed-c215-497e-a598-d16d0090b68f)

It probably broke as part of this commit:

- https://github.com/vitest-dev/eslint-plugin-vitest/commit/5f1aac92cd9fd4aac35ab14e15a0b1cc3b29236a#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R169

Ref:

- https://github.com/faker-js/faker/pull/3358