### PR TITLE
fix(consistent-test-it): Remove duplicate imports inside the import statement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { Linter } from '@typescript-eslint/utils/ts-eslint'
-import type { ESLint } from "eslint"
+import type { ESLint } from 'eslint'
 import { version } from '../package.json'
 import lowerCaseTitle, { RULE_NAME as lowerCaseTitleName } from './rules/prefer-lowercase-title'
 import maxNestedDescribe, { RULE_NAME as maxNestedDescribeName } from './rules/max-nested-describe'
@@ -71,8 +71,8 @@ const createConfig = <R extends Linter.RulesRecord>(rules: R) => (
       [`vitest/${ruleName}`]: rules[ruleName]
     }
   }, {})) as {
-    [K in keyof R as `vitest/${Extract<K, string>}`]: R[K]
-  }
+  [K in keyof R as `vitest/${Extract<K, string>}`]: R[K]
+}
 
 const createConfigLegacy = (rules: Record<string, string>) => ({
   plugins: ['@vitest'],
@@ -159,7 +159,6 @@ const recommended = {
   [requireLocalTestContextForConcurrentSnapshotsName]: 'error',
   [noImportNodeTestName]: 'error'
 } as const
-
 
 const plugin = {
   meta: {

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -110,10 +110,21 @@ export default createEslintRule<
               node: specifier,
               data: { testFnKeyWork, oppositeTestKeyword },
               messageId: 'consistentMethod',
-              fix: fixer => fixer.replaceText(
-                specifier.local,
-                testFnDisabled
-              )
+              fix: (fixer) => {
+                const remainingSpecifiers = node.specifiers.filter(spec => spec.local.name !== oppositeTestKeyword)
+                if (remainingSpecifiers.length > 0) {
+                  const importText = remainingSpecifiers.map(spec => spec.local.name).join(', ')
+                  const lastSpecifierRange = node.specifiers.at(-1)?.range
+                  if (!lastSpecifierRange) return null
+
+                  return fixer.replaceTextRange(
+                    [node.specifiers[0].range[0], lastSpecifierRange[1]],
+                    importText
+                  )
+                }
+
+                return fixer.replaceText(specifier.local, testFnDisabled)
+              }
             })
           }
         }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,7 +10,7 @@ import {
   KnownMemberExpression,
   ParsedExpectVitestFnCall
 } from './parse-vitest-fn-call'
-import { Rule } from "eslint"
+import { Rule } from 'eslint'
 
 export interface PluginDocs {
   recommended?: boolean

--- a/tests/consistent-test-it.test.ts
+++ b/tests/consistent-test-it.test.ts
@@ -84,6 +84,33 @@ ruleTester.run(RULE_NAME, rule, {
       options: [{ fn: TestCaseName.it }],
       output: 'import { it } from "vitest"\nit("shows error", () => {});',
       errors: [{ messageId: 'consistentMethod' }, { messageId: 'consistentMethod' }]
+    },
+    {
+      code: 'import { expect, test, it } from "vitest"\ntest("shows error", () => {});',
+      options: [{ fn: TestCaseName.it }],
+      output: 'import { expect, it } from "vitest"\nit("shows error", () => {});',
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test
+          },
+          line: 1,
+          column: 18,
+          endColumn: 22
+        },
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test
+          },
+          line: 2,
+          column: 1,
+          endColumn: 5
+        }
+      ]
     }
   ]
 })
@@ -300,6 +327,35 @@ ruleTester.run(RULE_NAME, rule, {
             testFnKeyWork: TestCaseName.test,
             oppositeTestKeyword: TestCaseName.it
           }
+        }
+      ]
+    },
+    {
+      code: 'import { expect, it, test } from "vitest"\nit("foo")',
+      output: 'import { expect, test } from "vitest"\ntest("foo")',
+      options: [
+        { withinDescribe: TestCaseName.test }
+      ],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it
+          },
+          line: 1,
+          column: 18,
+          endColumn: 20
+        },
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it
+          },
+          line: 2,
+          column: 1,
+          endColumn: 3
         }
       ]
     },


### PR DESCRIPTION
Fixed to also remove duplicate imports inside the import statement during the fix, as per the PR title.