### PR TITLE
fix(consistent-test-filename): match allTestPattern against full file path

### DIFF
--- a/src/rules/consistent-test-filename.ts
+++ b/src/rules/consistent-test-filename.ts
@@ -53,7 +53,8 @@ export default createEslintRule<
     const pattern = typeof patternRaw === 'string' ? new RegExp(patternRaw) : patternRaw
     const testPattern = typeof allTestPatternRaw === 'string' ? new RegExp(allTestPatternRaw) : allTestPatternRaw
 
-    const filename = path.basename(context.filename)
+    const { filename } = context
+
     if (!testPattern.test(filename))
       return {}
 

--- a/tests/consistent-test-filename.test.ts
+++ b/tests/consistent-test-filename.test.ts
@@ -15,6 +15,14 @@ ruleTester.run(`file-name`, rule, {
       filename: '1.spec.ts',
       errors: [{ messageId: 'consistentTestFilename' }],
       options: [{ pattern: String.raw`.*\.test\.ts$` }]
-    }
+    },
+    {
+      code: "export {}",
+      filename: "__tests__/2.ts",
+      errors: [{ messageId: "consistentTestFilename" }],
+      options: [
+        { allTestPattern: String.raw`__tests__`, pattern: String.raw`.*\.test\.ts$` },
+      ],
+    },
   ]
 })


### PR DESCRIPTION
closes https://github.com/vitest-dev/eslint-plugin-vitest/issues/673