### PR TITLE
docs: add at sign to v8 rules readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "vitest/max-nested-describe": [
+    "@vitest/max-nested-describe": [
       "error",
       {
         "max": 3


### PR DESCRIPTION
This might need a sanity check, but while using the version `v8.57.0` or lower setup rules as described in the readme, I noticed it did not work. As we define the plugin as `@vitest` I tried using that in the rules instead and that fixed my issues.