### PR TITLE
Fix "lint:js" Job and extend CI proposal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,17 @@ jobs:
       - name: install
         run: pnpm install
 
+      - name: format code
+        run: pnpm format:check
+
+      #- name: typecheck
+      #  run: pnpm tsc
+
+      - name: lint code
+        run: pnpm lint:js
+
       - name: test
         run: pnpm test:ci
 
       - name: build
         run: pnpm build
-
-        #      - name: typecheck
-        #run: pnpm tsc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: install
         run: pnpm install
 
-      - name: format code
+      - name: format
         run: pnpm format:check
 
       #- name: typecheck

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,6 @@ export default [
       vitest,
     },
     rules: {
-      ...styleConfigs.rules,
       'eslint-plugin/require-meta-docs-description': 'error',
     },
     settings: {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "unbuild --config unbuild.config.ts",
     "lint:eslint-docs": "pnpm build && eslint-doc-generator --check",
-    "lint:js": "eslint . --fix",
+    "lint:js": "eslint .",
     "lint": "concurrently --prefixColors auto \"pnpm:lint:*\"",
     "release": "bumpp package.json --commit --push --tag && pnpm build && pnpm publish",
     "stub": "unbuild --stub",

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -11,7 +11,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
   meta: {
     docs: {
       description:
-        'Disallow using the `f` and `x` prefixes in favour of `.only` and `.skip`',
+        'disallow using the `f` and `x` prefixes in favour of `.only` and `.skip`',
       recommended: false,
     },
     type: 'suggestion',


### PR DESCRIPTION
Running `pnpm lint:js` generates small issues, which leads to eslint plugin in vscode or other editors not working properly. - This is fixed with first commit.

Additionally to ensure upcoming issues, adding the the `pnpm lint:js` job to the CI might be a good way, to prevent. To achieve that, I changed the `pnpm lint:js` to not fix anymore, just check. To run the fix locally it could be achieved by running: `pnpm lint:js --fix`.