### PR TITLE
Proposal to fix "pnpm tsc"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 21.x]
+        node-version: [22.x, 24.x]
         os: [ubuntu-latest, windows-latest]
 
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: format
         run: pnpm format:check
 
+      - name: check types
+        run: pnpm tsc
+
       - name: build
         run: pnpm build
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import type { Linter } from '@typescript-eslint/utils/ts-eslint'
-import type { ESLint } from 'eslint'
 import { version } from '../package.json'
 import lowerCaseTitle, {
   RULE_NAME as lowerCaseTitleName,
@@ -397,7 +396,7 @@ const plugin = {
     recommended: {
       name: '@vitest/recommended',
       plugins: {
-        get vitest(): ESLint.Plugin {
+        get vitest() {
           return plugin
         },
       },
@@ -406,7 +405,7 @@ const plugin = {
     all: {
       name: '@vitest/all',
       plugins: {
-        get vitest(): ESLint.Plugin {
+        get vitest() {
           return plugin
         },
       },
@@ -437,6 +436,6 @@ const plugin = {
       },
     },
   },
-} satisfies ESLint.Plugin
+}
 
 export default plugin

--- a/src/rules/require-mock-type-parameters.ts
+++ b/src/rules/require-mock-type-parameters.ts
@@ -43,9 +43,9 @@ export default createEslintRule<Options[], MESSAGE_IDS>({
         if (vitestFnCall?.type !== 'vi') return
 
         for (const member of vitestFnCall?.members) {
-          // @ts-expect-error TS2339
           if (
             !('name' in member) ||
+            // @ts-expect-error TS2339
             member.parent.parent.typeArguments !== undefined
           )
             continue

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,7 +10,6 @@ import {
   KnownMemberExpression,
   ParsedExpectVitestFnCall,
 } from './parse-vitest-fn-call'
-import { Rule } from 'eslint'
 
 export interface PluginDocs {
   recommended?: boolean

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,21 +17,10 @@ export interface PluginDocs {
   requiresTypeChecking?: boolean
 }
 
-export function createEslintRule<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
->(
-  rule: Readonly<
-    ESLintUtils.RuleWithMetaAndName<TOptions, TMessageIds, PluginDocs>
-  >,
-) {
-  const createRule = ESLintUtils.RuleCreator<PluginDocs>(
-    (ruleName) =>
-      `https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/${ruleName}.md`,
-  )
-
-  return createRule(rule) as unknown as Rule.RuleModule
-}
+export const createEslintRule = ESLintUtils.RuleCreator<PluginDocs>(
+  (name) =>
+    `https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/${name}.md`,
+)
 
 export const joinNames = (a: string | null, b: string | null): string | null =>
   a && b ? `${a}.${b}` : null

--- a/tests/no-importing-vitest-globals.test.ts
+++ b/tests/no-importing-vitest-globals.test.ts
@@ -24,8 +24,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "import { describe } from 'vitest';",
       errors: [
         {
-          message:
-            "Do not import 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: '',
@@ -34,12 +34,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: "import { describe, it } from 'vitest';",
       errors: [
         {
-          message:
-            "Do not import 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'describe' },
         },
         {
-          message:
-            "Do not import 'it' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'it' },
         },
       ],
       output: '',
@@ -48,8 +48,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "import { describe, BenchFactory } from 'vitest';",
       errors: [
         {
-          message:
-            "Do not import 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: "import { BenchFactory } from 'vitest';",
@@ -58,8 +58,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "import { BenchFactory, describe } from 'vitest';",
       errors: [
         {
-          message:
-            "Do not import 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: "import { BenchFactory } from 'vitest';",
@@ -68,12 +68,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: "import { describe, BenchFactory, it } from 'vitest';",
       errors: [
         {
-          message:
-            "Do not import 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'describe' },
         },
         {
-          message:
-            "Do not import 'it' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'it' },
         },
       ],
       output: "import { BenchFactory } from 'vitest';",
@@ -82,12 +82,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: "import { BenchTask, describe, BenchFactory, it } from 'vitest';",
       errors: [
         {
-          message:
-            "Do not import 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'describe' },
         },
         {
-          message:
-            "Do not import 'it' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noImportingVitestGlobals',
+          data: { name: 'it' },
         },
       ],
       output: "import { BenchTask, BenchFactory } from 'vitest';",
@@ -96,8 +96,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const { describe } = require('vitest');",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: '',
@@ -106,8 +106,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const { describe } = require('vitest'), x = 1;",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: 'const x = 1;',
@@ -116,8 +116,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const x = 1, { describe } = require('vitest');",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: 'const x = 1;',
@@ -126,8 +126,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const x = 1, { describe } = require('vitest'), y = 2;",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: 'const x = 1, y = 2;',
@@ -136,12 +136,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const { describe, it } = require('vitest');",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
         {
-          message:
-            "Do not require 'it' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'it' },
         },
       ],
       output: '',
@@ -150,8 +150,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const { describe, BenchFactory } = require('vitest');",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: "const { BenchFactory } = require('vitest');",
@@ -160,8 +160,8 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const { BenchFactory, describe } = require('vitest');",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
       ],
       output: "const { BenchFactory } = require('vitest');",
@@ -170,12 +170,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const { describe, BenchFactory, it } = require('vitest');",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
         {
-          message:
-            "Do not require 'it' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'it' },
         },
       ],
       output: "const { BenchFactory } = require('vitest');",
@@ -184,12 +184,12 @@ ruleTester.run(RULE_NAME, rule, {
       code: "const { BenchTask, describe, BenchFactory, it } = require('vitest');",
       errors: [
         {
-          message:
-            "Do not require 'describe' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'describe' },
         },
         {
-          message:
-            "Do not require 'it' from 'vitest'. Use globals configuration instead.",
+          messageId: 'noRequiringVitestGlobals',
+          data: { name: 'it' },
         },
       ],
       output: "const { BenchTask, BenchFactory } = require('vitest');",

--- a/tests/prefer-importing-vitest-globals.test.ts
+++ b/tests/prefer-importing-vitest-globals.test.ts
@@ -14,73 +14,133 @@ ruleTester.run(RULE_NAME, rule, {
   invalid: [
     {
       code: "describe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { describe } from 'vitest';\ndescribe('suite', () => {});",
     },
     {
       code: "import { it } from 'vitest';\ndescribe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { it, describe } from 'vitest';\ndescribe('suite', () => {});",
     },
     {
       code: "import { describe } from 'jest';\ndescribe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { describe } from 'vitest';\nimport { describe } from 'jest';\ndescribe('suite', () => {});",
     },
     {
       code: "import vitest from 'vitest';\ndescribe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import vitest, { describe } from 'vitest';\ndescribe('suite', () => {});",
     },
     {
       code: "import * as abc from 'vitest';\ndescribe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { describe } from 'vitest';\nimport * as abc from 'vitest';\ndescribe('suite', () => {});",
     },
     {
       code: "import { \"default\" as vitest } from 'vitest'; describe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { \"default\" as vitest, describe } from 'vitest'; describe('suite', () => {});",
     },
     {
       code: "const x = require('something', 'else'); describe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { describe } from 'vitest';\nconst x = require('something', 'else'); describe('suite', () => {});",
     },
     {
       code: "const x = require('jest'); describe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { describe } from 'vitest';\nconst x = require('jest'); describe('suite', () => {});",
     },
     {
       code: "const vitest = require('vitest'); describe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "import { describe } from 'vitest';\nconst vitest = require('vitest'); describe('suite', () => {});",
     },
     {
       code: "const { ...rest } = require('vitest'); describe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "const { ...rest, describe } = require('vitest'); describe('suite', () => {});",
     },
     {
       code: "const { \"default\": vitest } = require('vitest'); describe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "const { \"default\": vitest, describe } = require('vitest'); describe('suite', () => {});",
     },
     {
       code: "const { it } = require('vitest');\ndescribe('suite', () => {});",
-      errors: [{ message: "Import 'describe' from 'vitest'" }],
+      errors: [
+        {
+          messageId: 'preferImportingVitestGlobals',
+          data: { name: 'describe' },
+        },
+      ],
       output:
         "const { it, describe } = require('vitest');\ndescribe('suite', () => {});",
     },


### PR DESCRIPTION
With this PR the `pnpm tsc` should succeed and can be activated in CI, if suits. I hope I didn't break any other things, but you'll find my way below:

So I went on reading into https://typescript-eslint.io/developers/custom-rules and changed `createEslintRule` accordingly. Then went on to https://github.com/typescript-eslint/examples/blob/main/packages/eslint-plugin-example-typed-linting/src/index.ts and changed return types in plugin accordingly.

Rest of the tsc issues (in tests) where just "hidden" due to tsc wasn't checked in CI - fixed them accordingly.

Hope this makes the changes understandable, I am happy to hear, also if I missed something.