### PR TITLE
feat: New rule `prefer-called-once`

### DIFF
--- a/docs/rules/prefer-called-once.md
+++ b/docs/rules/prefer-called-once.md
@@ -1,0 +1,29 @@
+# Enforce using `toBeCalledOnce()` or `toHaveBeenCalledOnce()` (`vitest/prefer-called-once`)
+
+
+
+## Rule Details
+
+This rule aims to enforce the use of `toBeCalledOnce()` or `toHaveBeenCalledOnce()` over `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)`.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+test('foo', () => {
+  const mock = vi.fn()
+  mock('foo')
+  expect(mock).toBeCalledTimes(1)
+  expect(mock).toHaveBeenCalledTimes(1)
+})
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+test('foo', () => {
+  const mock = vi.fn()
+  mock('foo')
+  expect(mock).toBeCalledWithOnce()
+  expect(mock).toHaveBeenCalledWithOnce()
+})
+```

--- a/src/rules/prefer-called-once.ts
+++ b/src/rules/prefer-called-once.ts
@@ -1,0 +1,65 @@
+import { createEslintRule, getAccessorValue } from '../utils'
+import {
+  getFirstMatcherArg,
+  parseVitestFnCall,
+} from '../utils/parse-vitest-fn-call'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils'
+
+export const RULE_NAME = 'prefer-called-once'
+type MESSAGE_IDS = 'preferCalledOnce'
+type Options = []
+
+type OneLiteral = TSESTree.Literal & {
+  value: 1
+}
+
+const isOneLiteral = (node: TSESTree.Node): node is OneLiteral =>
+  node.type === AST_NODE_TYPES.Literal && node.value === 1
+
+export default createEslintRule<Options, MESSAGE_IDS>({
+  name: RULE_NAME,
+  meta: {
+    docs: {
+      description:
+        'enforce using `toBeCalledOnce()` or `toHaveBeenCalledOnce()`',
+      recommended: false,
+    },
+    messages: {
+      preferCalledOnce: 'Prefer {{ replacedMatcherName }}()',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        const vitestFnCall = parseVitestFnCall(node, context)
+
+        if (vitestFnCall?.type !== 'expect') return
+
+        const { matcher } = vitestFnCall
+        const matcherName = getAccessorValue(matcher)
+
+        if (
+          ['toBeCalledTimes', 'toHaveBeenCalledTimes'].includes(matcherName) &&
+          vitestFnCall.args.length === 1 &&
+          isOneLiteral(getFirstMatcherArg(vitestFnCall))
+        ) {
+          const replacedMatcherName = matcherName.replace('Times', 'Once')
+
+          context.report({
+            data: { replacedMatcherName },
+            messageId: 'preferCalledOnce',
+            node: matcher,
+            fix: (fixer) => [
+              fixer.replaceText(matcher, replacedMatcherName),
+              fixer.remove(vitestFnCall.args[0]),
+            ],
+          })
+        }
+      },
+    }
+  },
+})

--- a/tests/prefer-called-once.test.ts
+++ b/tests/prefer-called-once.test.ts
@@ -1,0 +1,94 @@
+import rule, { RULE_NAME } from '../src/rules/prefer-called-once'
+import { ruleTester } from './ruleTester'
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    'expect(fn).toBeCalledOnce();',
+    'expect(fn).toHaveBeenCalledOnce();',
+    'expect(fn).toBeCalledTimes(2);',
+    'expect(fn).toHaveBeenCalledTimes(2);',
+    'expect(fn).toBeCalledTimes(expect.anything());',
+    'expect(fn).toHaveBeenCalledTimes(expect.anything());',
+    'expect(fn).not.toBeCalledOnce();',
+    'expect(fn).rejects.not.toBeCalledOnce();',
+    'expect(fn).not.toHaveBeenCalledOnce();',
+    'expect(fn).resolves.not.toHaveBeenCalledOnce();',
+    'expect(fn).toBeCalledTimes(0);',
+    'expect(fn).toHaveBeenCalledTimes(0);',
+    'expect(fn);',
+  ],
+  invalid: [
+    {
+      code: 'expect(fn).toBeCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferCalledOnce',
+          data: { replacedMatcherName: 'toBeCalledOnce' },
+          column: 12,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).toBeCalledOnce();',
+    },
+    {
+      code: 'expect(fn).toHaveBeenCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferCalledOnce',
+          data: { replacedMatcherName: 'toHaveBeenCalledOnce' },
+          column: 12,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).toHaveBeenCalledOnce();',
+    },
+    {
+      code: 'expect(fn).not.toBeCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferCalledOnce',
+          data: { replacedMatcherName: 'toBeCalledOnce' },
+          column: 16,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).not.toBeCalledOnce();',
+    },
+    {
+      code: 'expect(fn).not.toHaveBeenCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferCalledOnce',
+          data: { replacedMatcherName: 'toHaveBeenCalledOnce' },
+          column: 16,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).not.toHaveBeenCalledOnce();',
+    },
+    {
+      code: 'expect(fn).resolves.toBeCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferCalledOnce',
+          data: { replacedMatcherName: 'toBeCalledOnce' },
+          column: 21,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).resolves.toBeCalledOnce();',
+    },
+    {
+      code: 'expect(fn).resolves.toHaveBeenCalledTimes(1);',
+      errors: [
+        {
+          messageId: 'preferCalledOnce',
+          data: { replacedMatcherName: 'toHaveBeenCalledOnce' },
+          column: 21,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).resolves.toHaveBeenCalledOnce();',
+    },
+  ],
+})


### PR DESCRIPTION
I would like to propose a new rule `prefer-called-once` that enforces the use of `toBeCalledOnce()` or `toHaveBeenCalledOnce()` over `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)`.

Examples of **incorrect** code for this rule:

```ts
test('foo', () => {
  const mock = vi.fn()
  mock('foo')
  expect(mock).toBeCalledTimes(1)
  expect(mock).toHaveBeenCalledTimes(1)
})
```

Examples of **correct** code for this rule:

```ts
test('foo', () => {
  const mock = vi.fn()
  mock('foo')
  expect(mock).toBeCalledWithOnce()
  expect(mock).toHaveBeenCalledWithOnce()
})
```