### PR TITLE
feat: New rule prefer-called-times

### DIFF
--- a/docs/rules/prefer-called-times.md
+++ b/docs/rules/prefer-called-times.md
@@ -1,0 +1,27 @@
+# Enforce using `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` (`vitest/prefer-called-times`)
+
+## Rule Details
+
+This rule aims to enforce the use of `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` over `toBeCalledOnce()` or `toHaveBeenCalledOnce()`.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+test('foo', () => {
+    const mock = vi.fn()
+    mock('foo')
+    expect(mock).toBeCalledOnce()
+    expect(mock).toHaveBeenCalledOnce()
+})
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+test('foo', () => {
+  const mock = vi.fn()
+  mock('foo')
+  expect(mock).toBeCalledTimes(1)
+  expect(mock).toHaveBeenCalledTimes(1)
+})
+```

--- a/src/rules/prefer-called-times.ts
+++ b/src/rules/prefer-called-times.ts
@@ -1,0 +1,67 @@
+import { createEslintRule, getAccessorValue } from '../utils'
+import {
+  getFirstMatcherArg,
+  parseVitestFnCall,
+} from '../utils/parse-vitest-fn-call'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils'
+
+export const RULE_NAME = 'prefer-called-times'
+type MESSAGE_IDS = 'preferCalledTimes'
+type Options = []
+
+type OneLiteral = TSESTree.Literal & {
+  value: 1
+}
+
+const isOneLiteral = (node: TSESTree.Node): node is OneLiteral =>
+  node.type === AST_NODE_TYPES.Literal && node.value === 1
+
+export default createEslintRule<Options, MESSAGE_IDS>({
+  name: RULE_NAME,
+  meta: {
+    docs: {
+      description:
+        'enforce using `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)`',
+      recommended: false,
+    },
+    messages: {
+      preferCalledTimes: 'Prefer {{ replacedMatcherName }}(1)',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        const vitestFnCall = parseVitestFnCall(node, context)
+
+        if (vitestFnCall?.type !== 'expect') return
+
+        const { matcher } = vitestFnCall
+        const matcherName = getAccessorValue(matcher)
+
+        if (['toBeCalledOnce', 'toHaveBeenCalledOnce'].includes(matcherName)) {
+          const replacedMatcherName = matcherName.replace('Once', 'Times')
+
+          context.report({
+            data: { replacedMatcherName },
+            messageId: 'preferCalledTimes',
+            node: matcher,
+            fix: (fixer) => [
+              fixer.replaceText(matcher, replacedMatcherName),
+              fixer.insertTextAfterRange(
+                  [
+                    vitestFnCall.matcher.range[0],
+                    vitestFnCall.matcher.range[1] + 1,
+                  ],
+                  '1',
+              ),
+            ],
+          })
+        }
+      },
+    }
+  },
+})

--- a/tests/prefer-called-times.test.ts
+++ b/tests/prefer-called-times.test.ts
@@ -1,0 +1,94 @@
+import rule, { RULE_NAME } from '../src/rules/prefer-called-times'
+import { ruleTester } from './ruleTester'
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    'expect(fn).toBeCalledTimes(1);',
+    'expect(fn).toHaveBeenCalledTimes(1);',
+    'expect(fn).toBeCalledTimes(2);',
+    'expect(fn).toHaveBeenCalledTimes(2);',
+    'expect(fn).toBeCalledTimes(expect.anything());',
+    'expect(fn).toHaveBeenCalledTimes(expect.anything());',
+    'expect(fn).not.toBeCalledTimes(2);',
+    'expect(fn).rejects.not.toBeCalledTimes(1);',
+    'expect(fn).not.toHaveBeenCalledTimes(1);',
+    'expect(fn).resolves.not.toHaveBeenCalledTimes(1);',
+    'expect(fn).toBeCalledTimes(0);',
+    'expect(fn).toHaveBeenCalledTimes(0);',
+    'expect(fn);',
+  ],
+  invalid: [
+    {
+      code: 'expect(fn).toBeCalledOnce();',
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          data: { replacedMatcherName: 'toBeCalledTimes' },
+          column: 12,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).toBeCalledTimes(1);',
+    },
+    {
+      code: 'expect(fn).toHaveBeenCalledOnce();',
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          data: { replacedMatcherName: 'toHaveBeenCalledTimes' },
+          column: 12,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).toHaveBeenCalledTimes(1);',
+    },
+    {
+      code: 'expect(fn).not.toBeCalledOnce();',
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          data: { replacedMatcherName: 'toBeCalledTimes' },
+          column: 16,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).not.toBeCalledTimes(1);',
+    },
+    {
+      code: 'expect(fn).not.toHaveBeenCalledOnce();',
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          data: { replacedMatcherName: 'toHaveBeenCalledTimes' },
+          column: 16,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).not.toHaveBeenCalledTimes(1);',
+    },
+    {
+      code: 'expect(fn).resolves.toBeCalledOnce();',
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          data: { replacedMatcherName: 'toBeCalledTimes' },
+          column: 21,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).resolves.toBeCalledTimes(1);',
+    },
+    {
+      code: 'expect(fn).resolves.toHaveBeenCalledOnce();',
+      errors: [
+        {
+          messageId: 'preferCalledTimes',
+          data: { replacedMatcherName: 'toHaveBeenCalledTimes' },
+          column: 21,
+          line: 1,
+        },
+      ],
+      output: 'expect(fn).resolves.toHaveBeenCalledTimes(1);',
+    },
+  ],
+})


### PR DESCRIPTION
I would like to propose a new rule `prefer-called-once` that enforces the use of `toBeCalledTimes(1)` or `toHaveBeenCalledTimes(1)` over `toBeCalledOnce()` or `toHaveBeenCalledOnce()`.

Examples of **incorrect** code for this rule:

```ts
test('foo', () => {
    const mock = vi.fn()
    mock('foo')
    expect(mock).toBeCalledOnce()
    expect(mock).toHaveBeenCalledOnce()
})
```

Examples of **correct** code for this rule:

```ts
test('foo', () => {
  const mock = vi.fn()
  mock('foo')
  expect(mock).toBeCalledTimes(1)
  expect(mock).toHaveBeenCalledTimes(1)
})
```