### PR TITLE
fix(prefer-importing-vitest-globals): ignore local vars with vitest global names

### DIFF
--- a/tests/prefer-importing-vitest-globals.test.ts
+++ b/tests/prefer-importing-vitest-globals.test.ts
@@ -10,6 +10,9 @@ ruleTester.run(RULE_NAME, rule, {
     "const { describe } = require('vitest'); describe('suite', () => {});",
     "const { describe, it } = require('vitest'); describe('suite', () => {});",
     "const { describe, describe } = require('vitest'); describe('suite', () => {});",
+    "import { describe, expect, it } from 'vitest'; describe('suite', () => { it('test', () => { let test = 5; expect(test).toBe(5); }); });",
+    "import { describe, expect, it } from 'vitest'; describe('suite', () => { it('test', () => { const test = () => true; expect(test()).toBe(true); }); });",
+    "import { describe, expect, it } from 'vitest'; describe('suite', () => { it('test', () => { function fn(test) { return test; } expect(fn(5)).toBe(5); }); });",
   ],
   invalid: [
     {


### PR DESCRIPTION
Fix false positives in `prefer-importing-vitest-globals` rule.

The `prefer-importing-vitest-globals` rule was incorrectly flagging local variables, function parameters, and other local bindings that happened to have the same name as vitest globals (like `test`, `describe`, `it`, etc.).

For example, this code would incorrectly trigger the rule:

```ts
import { describe, expect, it } from 'vitest'

describe('test suite', () => {
  it('should work', () => {
    let test = createTestWithParameters(3) // Rule incorrectly flagged this
    expect(test()).toBeTruthy()
  })
})
```

I encountered an issue in my project:
https://github.com/azat-io/eslint-plugin-de-morgan/blob/main/test/utils/create-test-with-parameters.test.ts

Added proper scope analysis to distinguish between:

- Local bindings (variables, parameters, function declarations) - should be ignored
- Import bindings from non-vitest modules - should be flagged
- Actual vitest global function calls - should be flagged if not imported

The rule now correctly identifies when an identifier refers to a local binding rather than a missing vitest global import.
