### PR TITLE
Repair parse error in `vitest/prefer-expect-assertions`

### DIFF
--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -202,6 +202,7 @@ export default createEslintRule<Options[], MessageIds>({
 
         if (
           vitestFnCall?.head.type === 'testContext' &&
+          vitestFnCall.members[0] &&
           vitestFnCall.members[0].type === AST_NODE_TYPES.Identifier &&
           vitestFnCall.members[0].name === 'expect'
         ) {

--- a/tests/prefer-expect-assertions.test.ts
+++ b/tests/prefer-expect-assertions.test.ts
@@ -16,6 +16,11 @@ ruleTester.run(RULE_NAME, rule, {
     await expect(Promise.resolve(null)).resolves.toBeNull();
   });
     `,
+    `it("it1", () => {
+    expect.assertions(0);
+    const foo = { bar({ baz }) { baz(); } };
+  });
+    `,
     {
       code: `
    const expectNumbersToBeGreaterThan = (numbers, value) => {
@@ -472,6 +477,33 @@ it('my test description', (context) => {context.expect.assertions();
     expect(number).toBeGreaterThan(5);
      }
    });
+    `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `it("it1", () => {
+    const foo = { bar({ baz }) { baz(); } };
+  });
+    `,
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          suggestions: [
+            {
+              messageId: 'suggestAddingHasAssertions',
+              output: `it("it1", () => {expect.hasAssertions();
+    const foo = { bar({ baz }) { baz(); } };
+  });
+    `,
+            },
+            {
+              messageId: 'suggestAddingAssertions',
+              output: `it("it1", () => {expect.assertions();
+    const foo = { bar({ baz }) { baz(); } };
+  });
     `,
             },
           ],


### PR DESCRIPTION
# Test case

```ts
it("it1", () => {
    expect.assertions(0);
    const foo = { bar({ baz }) { baz(); } };
});
```

# Result

`members` is an empty array [here](https://github.com/vitest-dev/eslint-plugin-vitest/blob/b44c039d47fd77b001262f97d8349e2cb2c4101b/src/rules/prefer-expect-assertions.ts#L205-L206).

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/prefer-expect-assertions.test.ts > prefer-expect-assertions > valid > it("it1", () => {
    expect.assertions(0);
    const foo = { bar({ baz }) { baz(); } };
  });
    
Error: Caught an error while linting
 ❯ Linter.linter.verify node_modules/.pnpm/@typescript-eslint+rule-tester@8.24.1_eslint@9.20.0_jiti@2.4.2__typescript@5.7.3/node_modules/@typescript-eslint/rule-tester/src/RuleTester.ts:239:19
 ❯ RuleTester.runRuleForItem node_modules/.pnpm/@typescript-eslint+rule-tester@8.24.1_eslint@9.20.0_jiti@2.4.2__typescript@5.7.3/node_modules/@typescript-eslint/rule-tester/src/RuleTester.ts:799:27
 ❯ RuleTester.#testValidTemplate node_modules/.pnpm/@typescript-eslint+rule-tester@8.24.1_eslint@9.20.0_jiti@2.4.2__typescript@5.7.3/node_modules/@typescript-eslint/rule-tester/src/RuleTester.ts:884:25
 ❯ node_modules/.pnpm/@typescript-eslint+rule-tester@8.24.1_eslint@9.20.0_jiti@2.4.2__typescript@5.7.3/node_modules/@typescript-eslint/rule-tester/src/RuleTester.ts:568:40

Caused by: TypeError: Cannot read properties of undefined (reading 'type')
Occurred while linting file.ts:3
Rule: "@rule-tester/prefer-expect-assertions"
 ❯ CallExpression src/rules/prefer-expect-assertions.ts:205:35
 ❯ ruleErrorHandler node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/linter.js:1160:48
 ❯ node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/safe-emitter.js:45:58
 ❯ Object.emit node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/safe-emitter.js:45:38
 ❯ NodeEventGenerator.applySelector node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/node-event-generator.js:297:26
 ❯ NodeEventGenerator.applySelectors node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/node-event-generator.js:326:22
 ❯ NodeEventGenerator.enterNode node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/node-event-generator.js:337:14
 ❯ runRules node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/linter.js:1204:40
 ❯ Linter.#flatVerifyWithoutProcessors node_modules/.pnpm/eslint@9.20.0_jiti@2.4.2/node_modules/eslint/lib/linter/linter.js:2001:31

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { ruleId: '@rule-tester/prefer-expect-assertions', currentNode: { type: 'CallExpression', arguments: [], callee: { type: 'Identifier', decorators: [], name: 'baz', optional: false, typeAnnotation: undefined, range: [ 77, 80 ], loc: { end: { column: 36, line: 3 }, start: { column: 33, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, optional: false, typeArguments: undefined, range: [ 77, 82 ], loc: { end: { column: 38, line: 3 }, start: { column: 33, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'ExpressionStatement', directive: undefined, expression: [Circular], range: [ 77, 83 ], loc: { end: { column: 39, line: 3 }, start: { column: 33, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'BlockStatement', body: [ [Circular] ], range: [ 75, 85 ], loc: { end: { column: 41, line: 3 }, start: { column: 31, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'FunctionExpression', range: [ 65, 85 ], async: false, body: [Circular], declare: false, expression: false, generator: false, id: null, params: [ { type: 'ObjectPattern', decorators: [], optional: false, properties: [ { type: 'Property', computed: false, key: { type: 'Identifier', decorators: [], name: 'baz', optional: false, typeAnnotation: undefined, range: [ 68, 71 ], loc: { end: { column: 27, line: 3 }, start: { column: 24, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, kind: 'init', method: false, optional: false, shorthand: true, value: { type: 'Identifier', decorators: [], name: 'baz', optional: false, typeAnnotation: undefined, range: [ 68, 71 ], loc: { end: { column: 27, line: 3 }, start: { column: 24, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, range: [ 68, 71 ], loc: { end: { column: 27, line: 3 }, start: { column: 24, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] } ], typeAnnotation: undefined, range: [ 66, 73 ], loc: { end: { column: 29, line: 3 }, start: { column: 22, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] } ], returnType: undefined, typeParameters: undefined, loc: { end: { column: 41, line: 3 }, start: { column: 21, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'Property', computed: false, key: { type: 'Identifier', decorators: [], name: 'bar', optional: false, typeAnnotation: undefined, range: [ 62, 65 ], loc: { end: { column: 21, line: 3 }, start: { column: 18, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, kind: 'init', method: true, optional: false, shorthand: false, value: [Circular], range: [ 62, 85 ], loc: { end: { column: 41, line: 3 }, start: { column: 18, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'ObjectExpression', properties: [ [Circular] ], range: [ 60, 87 ], loc: { end: { column: 43, line: 3 }, start: { column: 16, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'VariableDeclarator', definite: false, id: { type: 'Identifier', decorators: [], name: 'foo', optional: false, typeAnnotation: undefined, range: [ 54, 57 ], loc: { end: { column: 13, line: 3 }, start: { column: 10, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, init: [Circular], range: [ 54, 87 ], loc: { end: { column: 43, line: 3 }, start: { column: 10, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'VariableDeclaration', declarations: [ [Circular] ], declare: false, kind: 'const', range: [ 48, 88 ], loc: { end: { column: 44, line: 3 }, start: { column: 4, line: 3 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'BlockStatement', body: [ { type: 'ExpressionStatement', directive: undefined, expression: { type: 'CallExpression', arguments: [ { type: 'Literal', raw: '0', value: +0, range: [ 40, 41 ], loc: { end: { column: 23, line: 2 }, start: { column: 22, line: 2 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] } ], callee: { type: 'MemberExpression', computed: false, object: { type: 'Identifier', decorators: [], name: 'expect', optional: false, typeAnnotation: undefined, range: [ 22, 28 ], loc: { end: { column: 10, line: 2 }, start: { column: 4, line: 2 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, optional: false, property: { type: 'Identifier', decorators: [], name: 'assertions', optional: false, typeAnnotation: undefined, range: [ 29, 39 ], loc: { end: { column: 21, line: 2 }, start: { column: 11, line: 2 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, range: [ 22, 39 ], loc: { end: { column: 21, line: 2 }, start: { column: 4, line: 2 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, optional: false, typeArguments: undefined, range: [ 22, 42 ], loc: { end: { column: 24, line: 2 }, start: { column: 4, line: 2 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, range: [ 22, 43 ], loc: { end: { column: 25, line: 2 }, start: { column: 4, line: 2 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, [Circular] ], range: [ 16, 92 ], loc: { end: { column: 3, line: 4 }, start: { column: 16, line: 1 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'ArrowFunctionExpression', async: false, body: [Circular], expression: false, generator: false, id: null, params: [], returnType: undefined, typeParameters: undefined, range: [ 10, 92 ], loc: { end: { column: 3, line: 4 }, start: { column: 10, line: 1 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'CallExpression', arguments: [ { type: 'Literal', raw: '"it1"', value: 'it1', range: [ 3, 8 ], loc: { end: { column: 8, line: 1 }, start: { column: 3, line: 1 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, [Circular] ], callee: { type: 'Identifier', decorators: [], name: 'it', optional: false, typeAnnotation: undefined, range: [ +0, 2 ], loc: { end: { column: 2, line: 1 }, start: { column: +0, line: 1 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: [Circular] }, optional: false, typeArguments: undefined, range: [ +0, 93 ], loc: { end: { column: 4, line: 4 }, start: { column: +0, line: 1 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'ExpressionStatement', directive: undefined, expression: [Circular], range: [ +0, 94 ], loc: { end: { column: 5, line: 4 }, start: { column: +0, line: 1 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: { type: 'Program', range: [ +0, 99 ], body: [ [Circular] ], comments: [], sourceType: 'module', tokens: [ { type: 'Identifier', loc: { end: { column: 2, line: 1 }, start: { column: +0, line: 1 } }, range: [ +0, 2 ], value: 'it', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 3, line: 1 }, start: { column: 2, line: 1 } }, range: [ 2, 3 ], value: '(', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'String', loc: { end: { column: 8, line: 1 }, start: { column: 3, line: 1 } }, range: [ 3, 8 ], value: '"it1"', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 9, line: 1 }, start: { column: 8, line: 1 } }, range: [ 8, 9 ], value: ',', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 11, line: 1 }, start: { column: 10, line: 1 } }, range: [ 10, 11 ], value: '(', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 12, line: 1 }, start: { column: 11, line: 1 } }, range: [ 11, 12 ], value: ')', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 15, line: 1 }, start: { column: 13, line: 1 } }, range: [ 13, 15 ], value: '=>', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 17, line: 1 }, start: { column: 16, line: 1 } }, range: [ 16, 17 ], value: '{', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Identifier', loc: { end: { column: 10, line: 2 }, start: { column: 4, line: 2 } }, range: [ 22, 28 ], value: 'expect', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 11, line: 2 }, start: { column: 10, line: 2 } }, range: [ 28, 29 ], value: '.', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Identifier', loc: { end: { column: 21, line: 2 }, start: { column: 11, line: 2 } }, range: [ 29, 39 ], value: 'assertions', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 22, line: 2 }, start: { column: 21, line: 2 } }, range: [ 39, 40 ], value: '(', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Numeric', loc: { end: { column: 23, line: 2 }, start: { column: 22, line: 2 } }, range: [ 40, 41 ], value: '0', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 24, line: 2 }, start: { column: 23, line: 2 } }, range: [ 41, 42 ], value: ')', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 25, line: 2 }, start: { column: 24, line: 2 } }, range: [ 42, 43 ], value: ';', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Keyword', loc: { end: { column: 9, line: 3 }, start: { column: 4, line: 3 } }, range: [ 48, 53 ], value: 'const', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Identifier', loc: { end: { column: 13, line: 3 }, start: { column: 10, line: 3 } }, range: [ 54, 57 ], value: 'foo', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 15, line: 3 }, start: { column: 14, line: 3 } }, range: [ 58, 59 ], value: '=', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 17, line: 3 }, start: { column: 16, line: 3 } }, range: [ 60, 61 ], value: '{', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Identifier', loc: { end: { column: 21, line: 3 }, start: { column: 18, line: 3 } }, range: [ 62, 65 ], value: 'bar', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 22, line: 3 }, start: { column: 21, line: 3 } }, range: [ 65, 66 ], value: '(', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 23, line: 3 }, start: { column: 22, line: 3 } }, range: [ 66, 67 ], value: '{', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Identifier', loc: { end: { column: 27, line: 3 }, start: { column: 24, line: 3 } }, range: [ 68, 71 ], value: 'baz', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 29, line: 3 }, start: { column: 28, line: 3 } }, range: [ 72, 73 ], value: '}', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 30, line: 3 }, start: { column: 29, line: 3 } }, range: [ 73, 74 ], value: ')', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 32, line: 3 }, start: { column: 31, line: 3 } }, range: [ 75, 76 ], value: '{', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Identifier', loc: { end: { column: 36, line: 3 }, start: { column: 33, line: 3 } }, range: [ 77, 80 ], value: 'baz', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 37, line: 3 }, start: { column: 36, line: 3 } }, range: [ 80, 81 ], value: '(', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 38, line: 3 }, start: { column: 37, line: 3 } }, range: [ 81, 82 ], value: ')', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 39, line: 3 }, start: { column: 38, line: 3 } }, range: [ 82, 83 ], value: ';', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 41, line: 3 }, start: { column: 40, line: 3 } }, range: [ 84, 85 ], value: '}', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 43, line: 3 }, start: { column: 42, line: 3 } }, range: [ 86, 87 ], value: '}', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 44, line: 3 }, start: { column: 43, line: 3 } }, range: [ 87, 88 ], value: ';', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 3, line: 4 }, start: { column: 2, line: 4 } }, range: [ 91, 92 ], value: '}', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 4, line: 4 }, start: { column: 3, line: 4 } }, range: [ 92, 93 ], value: ')', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' }, { type: 'Punctuator', loc: { end: { column: 5, line: 4 }, start: { column: 4, line: 4 } }, range: [ 93, 94 ], value: ';', end: '<unserializable>: Use token.range[1] instead of token.end', start: '<unserializable>: Use token.range[0] instead of token.start' } ], loc: { end: { column: 4, line: 5 }, start: { column: +0, line: 1 } }, end: '<unserializable>: Use node.range[1] instead of node.end', start: '<unserializable>: Use node.range[0] instead of node.start', parent: null } } } } } } } } } } } } } }
```