### PR TITLE
fix(docs): fix incorrect rule name in vitest/require-mock-type-parameters example

### DIFF
--- a/docs/rules/require-mock-type-parameters.md
+++ b/docs/rules/require-mock-type-parameters.md
@@ -36,7 +36,7 @@ test('foo', () => {
 
 ```json
 {
-  "vitest/require-hook": [
+  "vitest/require-mock-type-parameters": [
     "error",
     {
       "checkImportFunctions": false


### PR DESCRIPTION
Fix the incorrect rule name in the vitest/require-mock-type-parameters example in the docs