### PR TITLE
fix(docs): Fix syntax errors padding-around-describe-blocks.md

### DIFF
--- a/docs/rules/padding-around-describe-blocks.md
+++ b/docs/rules/padding-around-describe-blocks.md
@@ -18,7 +18,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 const someText = 'hoge';
-describe("hoge" () => {});
+describe("hoge", () => {});
 describe('foo', () => {});
 ```
 
@@ -27,7 +27,7 @@ Examples of **correct** code for this rule:
 ```js
 const someText = 'hoge';
 
-describe("hoge" () => {});
+describe("hoge", () => {});
 
 describe('foo', () => {});
 ```


### PR DESCRIPTION
- Fix the syntax error of missing commas in describe function calls in the documentation to ensure the correctness of the code example.