### PR TITLE
require-top-level-describe: allow test context extend

### DIFF
--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -69,7 +69,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
         }
 
         if (numberOfDescribeBlocks === 0) {
-          if (vitestFnCall.type === 'test') {
+          if (vitestFnCall.type === 'test' && (vitestFnCall.members.length === 0 || !vitestFnCall.members.every(m => "name" in m && m.name === 'extend'))) {
             context.report({ node, messageId: 'unexpectedTestCase' })
             return
           }

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -69,7 +69,13 @@ export default createEslintRule<Options, MESSAGE_IDS>({
         }
 
         if (numberOfDescribeBlocks === 0) {
-          if (vitestFnCall.type === 'test' && (vitestFnCall.members.length === 0 || !vitestFnCall.members.every(m => "name" in m && m.name === 'extend'))) {
+          if (
+            vitestFnCall.type === 'test' &&
+            (vitestFnCall.members.length === 0 ||
+              !vitestFnCall.members.every(
+                (m) => 'name' in m && m.name === 'extend',
+              ))
+          ) {
             context.report({ node, messageId: 'unexpectedTestCase' })
             return
           }

--- a/tests/require-top-level-describe.test.ts
+++ b/tests/require-top-level-describe.test.ts
@@ -4,6 +4,7 @@ import { ruleTester } from './ruleTester'
 ruleTester.run(`${RULE_NAME}: require-top-level-describe`, rule, {
   valid: [
     'it.each()',
+    'it.extend()',
     'describe("test suite", () => { test("my test") });',
     'describe("test suite", () => { it("my test") });',
     `


### PR DESCRIPTION
Allows usage of `test.extend()` on top level.

I can also make it work with additional configuration flag if needed.