### PR TITLE
max-expects: fix when test context is used

### DIFF
--- a/tests/max-expects.test.ts
+++ b/tests/max-expects.test.ts
@@ -99,3 +99,88 @@ ruleTester.run(RULE_NAME, rule, {
     },
   ],
 })
+
+ruleTester.run(`${RULE_NAME} (with test context)`, rule, {
+  valid: [
+    `
+      import { it as base, describe, expect } from 'vitest'
+      const test = base.extend({})
+      test('should pass', () => { expect(true).toBeDefined() })
+      test('should pass', () => { expect(true).toBeDefined() })
+      test('should pass', () => { expect(true).toBeDefined() })
+      test('should pass', () => { expect(true).toBeDefined() })
+      test('should pass', () => { expect(true).toBeDefined() })
+      test('should pass', () => { expect(true).toBeDefined() })
+      test('should pass', () => { expect(true).toBeDefined() })
+    `,
+    `
+      import { it as base, describe, expect } from 'vitest'
+      const test = base.extend({})
+      describe('my tests', () => {
+        test('should pass', () => { expect(true).toBeDefined() })
+        test('should pass', () => { expect(true).toBeDefined() })
+        test('should pass', () => { expect(true).toBeDefined() })
+        test('should pass', () => { expect(true).toBeDefined() })
+        test('should pass', () => { expect(true).toBeDefined() })
+        test('should pass', () => { expect(true).toBeDefined() })
+        test('should pass', () => { expect(true).toBeDefined() })
+      })
+    `,
+  ],
+  invalid: [
+    {
+      code: `import { it as base, describe, expect } from 'vitest'
+        const it = base.extend({})
+        describe('my tests', () => {
+          it('should pass', () => { expect(true).toBeDefined() })
+          it('should pass', () => { expect(true).toBeDefined() })
+          it('should pass', () => { expect(true).toBeDefined() })
+          it('should pass', () => { expect(true).toBeDefined() })
+          it('should pass', () => { expect(true).toBeDefined() })
+          it('should pass', () => { expect(true).toBeDefined() })
+          it('should not pass', () => {
+            expect(true).toBeDefined()
+            expect(true).toBeDefined()
+            expect(true).toBeDefined()
+            expect(true).toBeDefined()
+            expect(true).toBeDefined()
+            expect(true).toBeDefined()
+          })
+        })
+      `,
+      errors: [
+        {
+          messageId: 'maxExpect',
+          line: 16,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: `import { it as base, describe, expect } from 'vitest'
+        const it = base.extend({})
+        it('should pass', () => { expect(true).toBeDefined() })
+        it('should pass', () => { expect(true).toBeDefined() })
+        it('should pass', () => { expect(true).toBeDefined() })
+        it('should pass', () => { expect(true).toBeDefined() })
+        it('should pass', () => { expect(true).toBeDefined() })
+        it('should pass', () => { expect(true).toBeDefined() })
+        it('should not pass', () => {
+          expect(true).toBeDefined()
+          expect(true).toBeDefined()
+          expect(true).toBeDefined()
+          expect(true).toBeDefined()
+          expect(true).toBeDefined()
+          expect(true).toBeDefined()
+        })
+      `,
+      errors: [
+        {
+          messageId: 'maxExpect',
+          line: 15,
+          column: 11,
+        },
+      ],
+    },
+  ],
+})

--- a/tests/valid-title.test.ts
+++ b/tests/valid-title.test.ts
@@ -697,24 +697,28 @@ ruleTester.run(RULE_NAME, rule, {
 ruleTester.run(RULE_NAME, rule, {
   valid: [
     {
-      code: 'const localTest = test.extend({})',
+      code: `
+        const it = test.extend({})
+        it('passes', () => {})
+      `,
       name: 'does not error when using test.extend',
     },
     {
       code: `import { it } from 'vitest'
 
-const test = it.extend({
-  fixture: [
-    async ({}, use) => {
-      setup()
-      await use()
-      teardown()
-    },
-    { auto: true }
-  ],
-})
+        const test = it.extend({
+          fixture: [
+            async ({}, use) => {
+              setup()
+              await use()
+              teardown()
+            },
+            { auto: true }
+          ],
+        })
 
-test('', () => {})`,
+        test('passes', () => {})
+      `,
       name: 'does not error when using it.extend',
     },
   ],


### PR DESCRIPTION
- Fixes `max-expects` when test function is created with test context
- Fixes empty title for `valid-title` rule with test context (no particular changes, the fix to max-expects highlighted the issue it the tests)
