### PR TITLE
Update prefer-called-exactly-once-with.md docs to have correct code

### DIFF
--- a/docs/rules/prefer-called-exactly-once-with.md
+++ b/docs/rules/prefer-called-exactly-once-with.md
@@ -13,7 +13,7 @@ test('foo', () => {
   const mock = jest.fn()
   mock('foo')
   expect(mock).toHaveBeenCalledOnce()
-  expect(mock).toHaveBeenCalledWith()
+  expect(mock).toHaveBeenCalledWith('foo')
 })
 ```
 


### PR DESCRIPTION
The readme was a little in-exact, this change makes it more accurate.