### PR TITLE
docs(prefer-called-exactly-once-with): update examples to use `vi.fn()` instead of `jest.fn()`

### DIFF
--- a/docs/rules/prefer-called-exactly-once-with.md
+++ b/docs/rules/prefer-called-exactly-once-with.md
@@ -10,7 +10,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 test('foo', () => {
-  const mock = jest.fn()
+  const mock = vi.fn()
   mock('foo')
   expect(mock).toHaveBeenCalledOnce()
   expect(mock).toHaveBeenCalledWith('foo')
@@ -19,7 +19,7 @@ test('foo', () => {
 
 ```js
 test('foo', () => {
-  const mock = jest.fn()
+  const mock = vi.fn()
   mock('foo')
   expect(mock).toHaveBeenCalledExactlyOnceWith('foo')
 })


### PR DESCRIPTION
- Fix documentation examples to use `vi.fn()` instead of `jest.fn()` in the `prefer-called-exactly-once-with` rule documentation.