### PR TITLE
fix(prefer-called-exactly-once-with): check for `toHaveBeenCalledOnce`

### DIFF
--- a/src/rules/prefer-called-exactly-once-with.ts
+++ b/src/rules/prefer-called-exactly-once-with.ts
@@ -192,6 +192,13 @@ export default createEslintRule<Options, MESSAGE_IDS>({
       ] of expectMatcherMap.entries()) {
         if (matcherReferences.length !== 2) continue
 
+        if (
+          !matcherReferences.some(
+            (reference) => reference.matcherName === 'toHaveBeenCalledOnce',
+          )
+        )
+          continue
+
         const targetArgNode = matcherReferences.find(
           (reference) => reference.matcherName === 'toHaveBeenCalledWith',
         )

--- a/tests/prefer-called-exactly-once-with.test.ts
+++ b/tests/prefer-called-exactly-once-with.test.ts
@@ -8,8 +8,12 @@ ruleTester.run(RULE_NAME, rule, {
     'expect(x).toHaveBeenCalledOnce();',
     `expect(x).toHaveBeenCalledWith('hoge');`,
     `
-      expect(x).toHaveBeenCalledOnce();
-      expect(y).toHaveBeenCalledWith('hoge');
+    expect(x).toHaveBeenCalledOnce();
+    expect(y).toHaveBeenCalledWith('hoge');
+    `,
+    `
+    expect(x).toHaveBeenCalledWith('hoge');
+    expect(x).toHaveBeenCalledWith('foo');
     `,
     `
     expect(x).toHaveBeenCalledOnce();


### PR DESCRIPTION
The `prefer-called-exactly-once-with` rule assumed that if two matchers for the same `expect` argument were found, they would be a `toHaveBeenCalledOnce` / `toHaveBeenCalledWith` pair:

```js
expect(x).toHaveBeenCalledOnce();
expect(x).toHaveBeenCalledWith('hoge');
```

However, they might as well be two `toHaveBeenCalledWith` calls:

```js
expect(x).toHaveBeenCalledWith('hoge');
expect(x).toHaveBeenCalledWith('foo');
```

In the latter case, the rule should not apply.

---

Under the assumption that this case is referred to in the issue, as other cases have already been covered (such as only one or more than 2 `toHaveBeenCalledWith` calls): Fixes #781


