### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           install-deps: false
 
-      - run: pnpx conventional-github-releaser -p angular
+      - name: Create release
         env:
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: pnpx changelogithub


### PR DESCRIPTION
@veritem I did a quick check in a private repository and it seems like `conventional-github-releaser` simply does not work anymore with GITHUB_TOKEN, even when all permissions are granted. Therefore, I suggest switching to the more actively maintained [`changelogithub`](https://github.com/antfu/changelogithub) tool.

Related to #791 