### PR TITLE
fix(consistent-test-filename): correct options type

### DIFF
--- a/src/rules/consistent-test-filename.ts
+++ b/src/rules/consistent-test-filename.ts
@@ -8,8 +8,8 @@ const defaultTestsPattern = /.*\.(test|spec)\.[tj]sx?$/
 export default createEslintRule<
   [
     Partial<{
-      pattern: RegExp | string
-      allTestPattern: RegExp | string
+      pattern: string
+      allTestPattern: string
     }>,
   ],
   'consistentTestFilename'
@@ -46,8 +46,8 @@ export default createEslintRule<
   },
   defaultOptions: [
     {
-      pattern: defaultPattern,
-      allTestPattern: defaultTestsPattern,
+      pattern: defaultPattern.source,
+      allTestPattern: defaultTestsPattern.source,
     },
   ],
 
@@ -55,16 +55,12 @@ export default createEslintRule<
     const { pattern: patternRaw, allTestPattern: allTestPatternRaw } =
       options[0]
 
-    const pattern =
-      typeof patternRaw === 'string' ? new RegExp(patternRaw) : patternRaw!
-    const testPattern =
-      typeof allTestPatternRaw === 'string'
-        ? new RegExp(allTestPatternRaw)
-        : allTestPatternRaw!
+    const pattern = new RegExp(patternRaw!)
+    const allTestPattern = new RegExp(allTestPatternRaw!)
 
     const { filename } = context
 
-    if (!testPattern.test(filename)) return {}
+    if (!allTestPattern.test(filename)) return {}
 
     return {
       Program: (p) => {
@@ -73,7 +69,7 @@ export default createEslintRule<
             node: p,
             messageId: 'consistentTestFilename',
             data: {
-              pattern: pattern.source,
+              pattern: patternRaw,
             },
           })
         }


### PR DESCRIPTION
Fixes #799 

In #785 the options schema was corrected from the previously invalid schema https://github.com/vitest-dev/eslint-plugin-vitest/blob/4321439dc3b92e27e2e7cd097563f45885412530/src/rules/consistent-test-filename.ts#L33-L38
to a valid one https://github.com/vitest-dev/eslint-plugin-vitest/blob/0d82d1ee3c9516dce3a09f057a1cf0ed8c81fba7/src/rules/consistent-test-filename.ts#L33-L37

As pointed out in #799 it used to be possible to use a `RegExp` for the rules options (due to the invalid schema and options retrievement via `context`).

Since, according to the official ESLint documentation [^1], rule options need to consist of JSON data types, I would stick with the fixed schema, which means the options must be passed as a string regex, for example:
```js
    'vitest/consistent-test-filename': ['error', { pattern: '.*\.test\.[tj]sx?$' }]
    // or if preferred
    'vitest/consistent-test-filename': ['error', { pattern: /.*\.test\.[tj]sx?$/.source }]
```

However, what I've missed in #785 is that the `Options` type should also just accept strings and that it makes more sense to pass the default options in this format as well.

[^1]: https://eslint.org/docs/latest/use/configure/configuration-files#configuring-rules