### PR TITLE
fix(no-done-callback): false positive when using `.for`

### DIFF
--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -58,7 +58,7 @@ export default createEslintRule<Options, MessageIds>({
   create(context) {
     return {
       CallExpression(node) {
-        const isVitestEach = /\.each$|\.concurrent$/.test(
+        const isVitestEach = /\.each$|\.for$|\.concurrent$/.test(
           getNodeName(node.callee) ?? '',
         )
 

--- a/tests/no-done-callback.test.ts
+++ b/tests/no-done-callback.test.ts
@@ -13,6 +13,7 @@ ruleTester.run(RULE_NAME, rule, {
     'it.each``("something", ({ a, b }) => {})',
     'it.each([])("something", (a, b) => { a(); b(); })',
     'it.each``("something", ({ a, b }) => { a(); b(); })',
+    'test.for([])("something", ([a, b], { expect }) => {})',
     'it.concurrent("something", (context) => {})',
     'it.concurrent("something", ({ expect }) => {})',
     'test("something", async function () {})',


### PR DESCRIPTION
Fixes #802 

FWIW the rule is deprecated, however since the fix is quite simple (adding `.for` to the respective regex) I'd say it still makes sense to adjust it accordingly.