### PR TITLE
chore: patch `eslint-doc-generator`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,8 @@ jobs:
       - name: Lint code
         run: pnpm lint:js
 
-      ### Temporarily disabled, see https://github.com/vitest-dev/eslint-plugin-vitest/issues/754
-      #- name: Lint docs
-      #  run: pnpm lint:eslint-docs
+      - name: Lint docs
+        run: pnpm lint:eslint-docs
 
   test:
     name: Test (Node.js ${{ matrix.node-version }}, ${{ matrix.os.name }})

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ export default [
 💭 Requires [type information](https://typescript-eslint.io/linting/typed-linting).\
 ❌ Deprecated.
 
-| Name                                                                                                                     | Description                                                                                     | 💼  | ⚠️  | 🚫  | 🔧  | 💡  | 💭  | ❌  |
+| Name                                                                                                                     | Description                                                                                     | 💼  | ⚠️  | 🚫  | 🔧  | 💡  | 💭  | ❌  |
 | :----------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
-| [consistent-test-filename](docs/rules/consistent-test-filename.md)                                                       | require .spec test file pattern                                                                 |     | 🌐  |     |     |     |     |     |
+| [consistent-test-filename](docs/rules/consistent-test-filename.md)                                                       | require test file pattern                                                                       |     | 🌐  |     |     |     |     |     |
 | [consistent-test-it](docs/rules/consistent-test-it.md)                                                                   | enforce using test or it but not both                                                           |     | 🌐  |     | 🔧  |     |     |     |
 | [consistent-vitest-vi](docs/rules/consistent-vitest-vi.md)                                                               | enforce using vitest or vi but not both                                                         |     | 🌐  |     | 🔧  |     |     |     |
 | [expect-expect](docs/rules/expect-expect.md)                                                                             | enforce having expectation in test body                                                         | ✅  | 🌐  |     |     |     |     |     |
@@ -229,6 +229,7 @@ export default [
 | [prefer-expect-type-of](docs/rules/prefer-expect-type-of.md)                                                             | enforce using `expectTypeOf` instead of `expect(typeof ...)`                                    |     | 🌐  |     | 🔧  |     |     |     |
 | [prefer-hooks-in-order](docs/rules/prefer-hooks-in-order.md)                                                             | enforce having hooks in consistent order                                                        |     | 🌐  |     |     |     |     |     |
 | [prefer-hooks-on-top](docs/rules/prefer-hooks-on-top.md)                                                                 | enforce having hooks before any test cases                                                      |     | 🌐  |     |     |     |     |     |
+| [prefer-import-in-mock](docs/rules/prefer-import-in-mock.md)                                                             | prefer dynamic import in mock                                                                   |     | 🌐  |     | 🔧  |     |     |     |
 | [prefer-importing-vitest-globals](docs/rules/prefer-importing-vitest-globals.md)                                         | enforce importing Vitest globals                                                                |     | 🌐  |     | 🔧  |     |     |     |
 | [prefer-lowercase-title](docs/rules/prefer-lowercase-title.md)                                                           | enforce lowercase titles                                                                        |     | 🌐  |     | 🔧  |     |     |     |
 | [prefer-mock-promise-shorthand](docs/rules/prefer-mock-promise-shorthand.md)                                             | enforce mock resolved/rejected shorthands for promises                                          |     | 🌐  |     | 🔧  |     |     |     |
@@ -254,7 +255,6 @@ export default [
 | [valid-expect-in-promise](docs/rules/valid-expect-in-promise.md)                                                         | require promises that have expectations in their chain to be valid                              |     | 🌐  |     |     |     |     |     |
 | [valid-title](docs/rules/valid-title.md)                                                                                 | enforce valid titles                                                                            | ✅  | 🌐  |     | 🔧  |     |     |     |
 | [warn-todo](docs/rules/warn-todo.md)                                                                                     | disallow `.todo` usage                                                                          |     |     |     |     |     |     |     |
-| [prefer-import-in-moc](docs/rules/prefer-import-in-moc.md)                                                               | enforce dynamic import in mock                                                                  | ✅  | 🌐  |     | 🔧  |     |     |     |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/consistent-test-filename.md
+++ b/docs/rules/consistent-test-filename.md
@@ -1,4 +1,4 @@
-# Require .spec test file pattern (`vitest/consistent-test-filename`)
+# Require test file pattern (`vitest/consistent-test-filename`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 

--- a/docs/rules/hoisted-apis-on-top.md
+++ b/docs/rules/hoisted-apis-on-top.md
@@ -1,4 +1,6 @@
-# Enforce hoisted APIs to be on top of the file (`@vitest/hoisted-apis-on-top`)
+# Enforce hoisted APIs to be on top of the file (`vitest/hoisted-apis-on-top`)
+
+⚠️ This rule _warns_ in the 🌐 `all` config.
 
 💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 

--- a/docs/rules/padding-around-describe-blocks.md
+++ b/docs/rules/padding-around-describe-blocks.md
@@ -17,17 +17,17 @@ its scope.
 Examples of **incorrect** code for this rule:
 
 ```js
-const someText = 'hoge';
-describe("hoge", () => {});
-describe('foo', () => {});
+const someText = 'hoge'
+describe('hoge', () => {})
+describe('foo', () => {})
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-const someText = 'hoge';
+const someText = 'hoge'
 
-describe("hoge", () => {});
+describe('hoge', () => {})
 
-describe('foo', () => {});
+describe('foo', () => {})
 ```

--- a/docs/rules/padding-around-test-blocks.md
+++ b/docs/rules/padding-around-test-blocks.md
@@ -17,31 +17,31 @@ its scope.
 Examples of **incorrect** code for this rule:
 
 ```js
-const someText = 'hoge';
-test("hoge", () => {});
-test('foo', () => {});
+const someText = 'hoge'
+test('hoge', () => {})
+test('foo', () => {})
 ```
 
 ```js
-const someText = 'hoge';
-it("hoge", () => {});
-it('foo', () => {});
+const someText = 'hoge'
+it('hoge', () => {})
+it('foo', () => {})
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-const someText = 'hoge';
+const someText = 'hoge'
 
-test("hoge", () => {});
+test('hoge', () => {})
 
-test('foo', () => {});
+test('foo', () => {})
 ```
 
 ```js
-const someText = 'hoge';
+const someText = 'hoge'
 
-it("hoge", () => {});
+it('hoge', () => {})
 
-it('foo', () => {});
+it('foo', () => {})
 ```

--- a/docs/rules/prefer-called-once.md
+++ b/docs/rules/prefer-called-once.md
@@ -1,6 +1,6 @@
 # Enforce using `toBeCalledOnce()` or `toHaveBeenCalledOnce()` (`vitest/prefer-called-once`)
 
-⚠️ This rule _warns_ in the 🌐 `all` config.
+🚫 This rule is _disabled_ in the 🌐 `all` config.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/prefer-expect-assertions.md
+++ b/docs/rules/prefer-expect-assertions.md
@@ -50,19 +50,19 @@ when this option is enabled the following code will be considered incorrect:
 
 ```js
 test('assertions first', async () => {
-   const data = await fetchData();
-   expect(data).toBe('peanut butter');
-});
+  const data = await fetchData()
+  expect(data).toBe('peanut butter')
+})
 ```
 
 To fix this, you'll need to add `expect.assertions(1)` or `expect.hasAssertions()` as the first expression:
 
 ```js
 test('assertions first', async () => {
-   expect.assertions(1);
-   const data = await fetchData();
-   expect(data).toBe('peanut butter');
-});
+  expect.assertions(1)
+  const data = await fetchData()
+  expect(data).toBe('peanut butter')
+})
 ```
 
 `onlyFunctionsWithExpectInLoop` (default: `false`)

--- a/docs/rules/prefer-expect-type-of.md
+++ b/docs/rules/prefer-expect-type-of.md
@@ -1,4 +1,6 @@
-# Enforce using `expectTypeOf` instead of `expect(typeof ...)` (`@vitest/prefer-expect-type-of`)
+# Enforce using `expectTypeOf` instead of `expect(typeof ...)` (`vitest/prefer-expect-type-of`)
+
+⚠️ This rule _warns_ in the 🌐 `all` config.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/docs/rules/prefer-import-in-mock.md
+++ b/docs/rules/prefer-import-in-mock.md
@@ -1,4 +1,4 @@
-# Enforce using dynamic import in `mock` (`vitest/prefer-import-in-mock`)
+# Prefer dynamic import in mock (`vitest/prefer-import-in-mock`)
 
 ⚠️ This rule _warns_ in the 🌐 `all` config.
 
@@ -13,11 +13,11 @@ This rule enforces using a dynamic import() in vi.mock(), which improves type in
 The following pattern is considered a warning:
 
 ```js
-vi.mock('./path/to/module');
+vi.mock('./path/to/module')
 ```
 
 The following pattern is not considered a warning:
 
 ```js
-vi.mock(import('./path/to/module'));
+vi.mock(import('./path/to/module'))
 ```

--- a/docs/rules/require-local-test-context-for-concurrent-snapshots.md
+++ b/docs/rules/require-local-test-context-for-concurrent-snapshots.md
@@ -24,10 +24,10 @@ Examples of **correct** code for this rule:
 
 ```js
 test.concurrent('myLogic', ({ expect }) => {
-    expect(true).toMatchSnapshot();
+  expect(true).toMatchSnapshot()
 })
 
 test.concurrent('myLogic', (context) => {
-    context.expect(true).toMatchSnapshot();
+  context.expect(true).toMatchSnapshot()
 })
 ```

--- a/patches/eslint-doc-generator@2.3.0.patch
+++ b/patches/eslint-doc-generator@2.3.0.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/lib/generator.js b/dist/lib/generator.js
+index 4f566d01905c725a337439769513cb3c67fcf228..354ad5e180d2f72546f6068359f53778918b3d20 100644
+--- a/dist/lib/generator.js
++++ b/dist/lib/generator.js
+@@ -36,7 +36,7 @@ export async function generate(path, options) {
+     const context = await getContext();
+     const { endOfLine } = context;
+     const plugin = await loadPlugin(path);
+-    const pluginPrefix = await getPluginPrefix(path);
++    const pluginPrefix = plugin.meta?.name ?? (await getPluginName(path));
+     const configsToRules = await resolveConfigsToRules(plugin);
+     if (!plugin.rules) {
+         throw new Error('Could not find exported `rules` object in ESLint plugin.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,11 @@ settings:
   excludeLinksFromLockfile: false
   injectWorkspacePackages: true
 
+patchedDependencies:
+  eslint-doc-generator@2.3.0:
+    hash: c394dd586d0143e4f9dda7bef5b303f792208be1c896d1af5c79d10f71fcbcef
+    path: patches/eslint-doc-generator@2.3.0.patch
+
 importers:
 
   .:
@@ -48,7 +53,7 @@ importers:
         version: 10.1.8(eslint@9.37.0(jiti@2.6.1))
       eslint-doc-generator:
         specifier: ^2.3.0
-        version: 2.3.0(eslint@9.37.0(jiti@2.6.1))(prettier@3.6.2)(typescript@5.9.3)
+        version: 2.3.0(patch_hash=c394dd586d0143e4f9dda7bef5b303f792208be1c896d1af5c79d10f71fcbcef)(eslint@9.37.0(jiti@2.6.1))(prettier@3.6.2)(typescript@5.9.3)
       eslint-plugin-eslint-plugin:
         specifier: ^7.0.0
         version: 7.0.0(eslint@9.37.0(jiti@2.6.1))
@@ -2966,7 +2971,7 @@ snapshots:
     dependencies:
       eslint: 9.37.0(jiti@2.6.1)
 
-  eslint-doc-generator@2.3.0(eslint@9.37.0(jiti@2.6.1))(prettier@3.6.2)(typescript@5.9.3):
+  eslint-doc-generator@2.3.0(patch_hash=c394dd586d0143e4f9dda7bef5b303f792208be1c896d1af5c79d10f71fcbcef)(eslint@9.37.0(jiti@2.6.1))(prettier@3.6.2)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       ajv: 8.17.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,9 @@
-savePrefix: ^
 injectWorkspacePackages: true
+
 onlyBuiltDependencies:
   - esbuild
+
+patchedDependencies:
+  eslint-doc-generator@2.3.0: patches/eslint-doc-generator@2.3.0.patch
+
+savePrefix: ^


### PR DESCRIPTION
Patch `eslint-doc-generator` with a stripped down version of https://github.com/bmish/eslint-doc-generator/pull/816.
Hopefully, this PR will eventually be accepted, but until then, this enables us to keep the docs up-to-date more easily.

Fixes #805, fixes #754, fixes #634