### PR TITLE
fix: workaround for plugin type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,19 @@ npm install @vitest/eslint-plugin --save-dev
 Make sure you're running ESLint `v9.0.0` or higher for the latest version of this plugin to work. The following example is how your `eslint.config.js` should be setup for this plugin to work for you.
 
 ```js
+import { defineConfig } from 'eslint/config'
 import vitest from '@vitest/eslint-plugin'
 
-export default [
-  {
-    files: ['tests/**'], // or any other pattern
-    plugins: {
-      vitest,
-    },
-    rules: {
-      ...vitest.configs.recommended.rules, // you can also use vitest.configs.all.rules to enable all rules
-      'vitest/max-nested-describe': ['error', { max: 3 }], // you can also modify rules' behavior using option like this
-    },
+export default defineConfig({
+  files: ['tests/**'], // or any other pattern
+  plugins: {
+    vitest,
   },
-]
+  rules: {
+    ...vitest.configs.recommended.rules, // you can also use vitest.configs.all.rules to enable all rules
+    'vitest/max-nested-describe': ['error', { max: 3 }], // you can also modify rules' behavior using option like this
+  },
+})
 ```
 
 If you're not using the latest version of ESLint (version `v8.57.0` or lower) you can setup this plugin using the following configuration
@@ -80,9 +79,20 @@ Vitest ships with an optional [type-testing feature](https://vitest.dev/guide/te
 If you're using this feature, you should also enabled `typecheck` in the settings for this plugin. This ensures that rules like [expect-expect](docs/rules/expect-expect.md) account for type-related assertions in tests.
 
 ```js
+import { defineConfig } from 'eslint/config'
+import tseslint from 'typescript-eslint'
 import vitest from '@vitest/eslint-plugin'
 
-export default [
+export default defineConfig(
+  // see https://typescript-eslint.io
+  tseslint.configs.recommended,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },
+  },
   {
     files: ['tests/**'], // or any other pattern
     plugins: {
@@ -102,7 +112,7 @@ export default [
       },
     },
   },
-]
+)
 ```
 
 ### Custom Fixtures
@@ -110,24 +120,23 @@ export default [
 If you're using custom fixtures in a separate file and importing them in your tests, you can let the plugin know about them by adding them to the `vitestImports` setting. The property accepts an array of strings or regular expressions that match the module names where your custom fixtures are defined.
 
 ```js
+import { defineConfig } from 'eslint/config'
 import vitest from '@vitest/eslint-plugin'
 
-export default [
-  {
-    files: ['tests/**'], // or any other pattern
-    plugins: {
-      vitest,
-    },
-    rules: {
-      ...vitest.configs.recommended.rules,
-    },
-    settings: {
-      vitest: {
-        vitestImports: ['@/tests/fixtures', /test-extend$/],
-      },
+export default defineConfig({
+  files: ['tests/**'], // or any other pattern
+  plugins: {
+    vitest,
+  },
+  rules: {
+    ...vitest.configs.recommended.rules,
+  },
+  settings: {
+    vitest: {
+      vitestImports: ['@/tests/fixtures', /test-extend$/],
     },
   },
-]
+})
 ```
 
 ### Shareable Configurations
@@ -139,14 +148,13 @@ This plugin exports a recommended configuration that enforces good testing pract
 To enable this configuration with `eslint.config.js`, use `vitest.configs.recommended`:
 
 ```js
+import { defineConfig } from 'eslint/config'
 import vitest from '@vitest/eslint-plugin'
 
-export default [
-  {
-    files: ['tests/**'], // or any other pattern
-    ...vitest.configs.recommended,
-  },
-]
+export default defineConfig({
+  files: ['tests/**'], // or any other pattern
+  ...vitest.configs.recommended,
+})
 ```
 
 #### All
@@ -154,14 +162,13 @@ export default [
 If you want to enable all rules instead of only some you can do so by adding the all configuration to your `eslint.config.js` config file:
 
 ```js
+import { defineConfig } from 'eslint/config'
 import vitest from '@vitest/eslint-plugin'
 
-export default [
-  {
-    files: ['tests/**'], // or any other pattern
-    ...vitest.configs.all,
-  },
-]
+export default defineConfig({
+  files: ['tests/**'], // or any other pattern
+  ...vitest.configs.all,
+})
 ```
 
 ### Rules

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -10,7 +10,6 @@ export default defineConfig(
   gitignore(),
   eslint.configs.recommended,
   tseslint.configs.recommended,
-  // @ts-expect-error see https://github.com/vitest-dev/eslint-plugin-vitest/issues/771
   vitest.configs.recommended,
   eslintPlugin.configs.recommended,
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Linter } from 'eslint'
+import type { ESLint, Linter, Rule } from 'eslint'
 import { version } from '../package.json'
 import lowerCaseTitle, { RULE_NAME as lowerCaseTitleName } from './rules/prefer-lowercase-title'
 import maxNestedDescribe, { RULE_NAME as maxNestedDescribeName } from './rules/max-nested-describe'
@@ -262,7 +262,7 @@ const rules = {
     [warnTodoName]: warnTodo,
     [preferImportInMockName]: preferImportInMock,
     [preferCalledExactlyOnceWithName]: preferCalledExactlyOnceWith
-} as const
+} as unknown as Record<string, Rule.RuleModule>
 
 const plugin = {
   meta: {
@@ -299,7 +299,7 @@ const plugin = {
     recommended: {
       name: 'vitest/recommended',
       plugins: {
-        get vitest() {
+        get vitest(): ESLint.Plugin {
           return plugin
         },
       },
@@ -308,7 +308,7 @@ const plugin = {
     all: {
       name: 'vitest/all',
       plugins: {
-        get vitest() {
+        get vitest(): ESLint.Plugin {
           return plugin
         },
       },
@@ -337,8 +337,8 @@ const plugin = {
           onTestFinished: 'writable',
         },
       },
-    } as const satisfies Linter.Config,
-  } as const,
-} as const
+    },
+  },
+} as const satisfies ESLint.Plugin
 
 export default plugin


### PR DESCRIPTION
A small workaround to mitigate the type conflicts mentioned in #771 and #761.

The issue originates from the current incompatibility of `ESLintUtils.RuleCreator` from `@typescript-eslint` and `defineConfig` from `eslint/config`, see https://github.com/typescript-eslint/typescript-eslint/issues/11543 for details.

By forcing the `rules` variable to be `Record<string, Rule.RuleModule>` we can make it compatible for now. I think that's acceptable as the rules itself are still type checked in their own modules.

The types of the configs remain detailed:
<img width="894" height="447" alt="eslint vitest config example" src="https://github.com/user-attachments/assets/5e920ac7-4f0f-4a6e-87f5-afa18daf2cfc" />

Fixes #771, fixes #761