### PR TITLE
docs(no-conditional-expect): add asymmetric matchers to example usage

### DIFF
--- a/docs/rules/no-conditional-expect.md
+++ b/docs/rules/no-conditional-expect.md
@@ -17,10 +17,7 @@ test('foo', () => {
   }
 })
 
-test.for([
-  null,
-  {bar: 'baz'}
-])('quux', (value) => {
+test.for([null, { bar: 'baz' }])('quux', (value) => {
   const expected = value === null ? expected : expect.stringContaining(expected)
   expect(actual).toEqual(expected)
 })
@@ -33,10 +30,10 @@ test('foo', () => {
   expect(1).toBe(1)
 })
 
-test.for([
-  null,
-  expect.objectContaining({bar: 'baz'})
-])('quux', (expected) => {
-  expect(actual).toEqual(expected)
-})
+test.for([null, expect.objectContaining({ bar: 'baz' })])(
+  'quux',
+  (expected) => {
+    expect(actual).toEqual(expected)
+  },
+)
 ```


### PR DESCRIPTION
This change clarifies that conditional asymmetric matchers are considered invalid, not just conditional assertions, as discussed in #834. It also clarifies the motivation for using the rule, so that the details section provides more than just information that can be inferred from the name of the rule. And to better demonstrate the utility of the rule, the incorrect usage example is updated to be a use case where an invalid condition is caught by the rule.