### PR TITLE
fix(unbound-method): ignore functions passed to `vi.mocked`

### DIFF
--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils'
-import { createEslintRule, getAccessorValue } from '../utils'
+import { createEslintRule, getAccessorValue, isIdentifier } from '../utils'
 import {
   findTopMostCallExpression,
   parseVitestFnCall,
@@ -74,6 +74,13 @@ export default createEslintRule<Options, MESSAGE_IDS>({
             findTopMostCallExpression(node.parent),
             context,
           )
+
+          if (
+            vitestFnCall?.type === 'vitest' &&
+            vitestFnCall.members.length >= 1 &&
+            isIdentifier(vitestFnCall.members[0], 'mocked')
+          )
+            return
 
           if (vitestFnCall?.type === 'expect') {
             const { matcher } = vitestFnCall


### PR DESCRIPTION
The bounding of methods being passed to `vi.mocked` doesn't matter, so should not be reported

(I'd have ported the test too, but it looks like the `eslint-plugin-jest` test suite for this rule has not been ported - I can look into that if desired?)