### PR TITLE
fix: treat `vitest` and `vi` the same

### DIFF
--- a/src/rules/consistent-vitest-vi.ts
+++ b/src/rules/consistent-vitest-vi.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils'
-import { createEslintRule } from '../utils'
+import { createEslintRule, isSupportedAccessor } from '../utils'
 import { UtilName } from '../utils/types'
 import { parseVitestFnCall } from '../utils/parse-vitest-fn-call'
 
@@ -95,7 +95,12 @@ export default createEslintRule<[Partial<{ fn: UtilName }>], MESSAGE_ID>({
       },
       CallExpression(node: TSESTree.CallExpression) {
         const vitestFnCall = parseVitestFnCall(node, context)
-        if (vitestFnCall?.type !== oppositeUtilKeyword) {
+
+        if (vitestFnCall?.type !== 'vi') {
+          return
+        }
+
+        if (!isSupportedAccessor(vitestFnCall.head.node, oppositeUtilKeyword)) {
           return
         }
 

--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -76,7 +76,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
           )
 
           if (
-            vitestFnCall?.type === 'vitest' &&
+            vitestFnCall?.type === 'vi' &&
             vitestFnCall.members.length >= 1 &&
             isIdentifier(vitestFnCall.members[0], 'mocked')
           )

--- a/src/utils/parse-vitest-fn-call.ts
+++ b/src/utils/parse-vitest-fn-call.ts
@@ -22,7 +22,6 @@ export type VitestFnType =
   | 'unknown'
   | 'hook'
   | 'vi'
-  | 'vitest'
   | 'expectTypeOf'
 
 interface ResolvedVitestFn {
@@ -128,9 +127,7 @@ const determineVitestFnType = (name: string): VitestFnType => {
 
   if (name === 'expectTypeOf') return 'expectTypeOf'
 
-  if (name === 'vi') return 'vi'
-
-  if (name === 'vitest') return 'vitest'
+  if (name === 'vi' || name === 'vitest') return 'vi'
 
   if (Object.prototype.hasOwnProperty.call(DescribeAlias, name))
     return 'describe'


### PR DESCRIPTION
My understanding is that `vitest` is a re-export of `vi` making it exactly the same so I don't think it makes sense to mark it as a different type of vitest function call - I'm guessing it was done like this for `consistent-vitest-vi` but that can be handled easily by checking the head node.

The only rule I know for sure that this impacts is `unbound-method`, but there might be a few others