### PR TITLE
fix(unbound-method): also account for `vi`

### DIFF
--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -76,7 +76,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
           )
 
           if (
-            vitestFnCall?.type === 'vitest' &&
+            (vitestFnCall?.type === 'vitest' || vitestFnCall?.type === 'vi') &&
             vitestFnCall.members.length >= 1 &&
             isIdentifier(vitestFnCall.members[0], 'mocked')
           )


### PR DESCRIPTION
I hadn't realised that `vi` and `vitest` are treated as different types of function calls, so we should be checking for both here - alternatively, I've opened #851 to have them treated the same which simplifies this