### PR TITLE
refactor: apply prettier to whole codebase

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/docs/rules/unbound-method.md
+++ b/docs/rules/unbound-method.md
@@ -15,7 +15,6 @@ to `expect` calls.
 
 This rule is enabled in the `all` config.
 
-
 ```json5
 {
   parser: '@typescript-eslint/parser',
@@ -40,6 +39,6 @@ This rule is enabled in the `all` config.
 }
 ```
 
-### Options 
+### Options
 
-Checkout [@typescript-eslint/unbound-method](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unbound-method.md)  options. including  `ignoreStatic`
+Checkout [@typescript-eslint/unbound-method](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unbound-method.md) options. including `ignoreStatic`

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint:eslint-docs": "pnpm build && eslint-doc-generator --check",
     "lint:js": "eslint",
     "release": "bumpp && pnpm build && pnpm publish",
-    "format": "prettier 'src/**/*.{ts,js}' --check",
+    "format": "prettier --check .",
     "test": "vitest",
     "update:chains": "node scripts/chain-permutations.ts",
     "update:rules": "node scripts/export-rules.ts",

--- a/tests/fixture/tsconfig.json
+++ b/tests/fixture/tsconfig.json
@@ -1,6 +1,6 @@
 {
-	"compilerOptions": {
-		"strict": true
-	},
-	"include": [ "*.ts", "*.tsx" ]
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["*.ts", "*.tsx"]
 }

--- a/tests/prefer-import-in-mock.test.ts
+++ b/tests/prefer-import-in-mock.test.ts
@@ -2,7 +2,6 @@ import rule, { RULE_NAME } from '../src/rules/prefer-import-in-mock'
 import { ruleTester } from './ruleTester'
 
 describe(RULE_NAME, () => {
-
   ruleTester.run(RULE_NAME, rule, {
     valid: [
       'vi.mock(import("foo"))',


### PR DESCRIPTION
Most of the codebase is already formatted how Prettier wants, so might as well enforce that