### PR TITLE
fix(prefer-mock-return-shorthand): ignore async implementations

### DIFF
--- a/src/rules/prefer-mock-return-shorthand.ts
+++ b/src/rules/prefer-mock-return-shorthand.ts
@@ -63,7 +63,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
 
         const [arg] = node.arguments
 
-        if (!isFunction(arg) || arg.params.length !== 0) {
+        if (!isFunction(arg) || arg.params.length !== 0 || arg.async) {
           return
         }
 

--- a/tests/prefer-mock-return-shorthand.test.ts
+++ b/tests/prefer-mock-return-shorthand.test.ts
@@ -22,6 +22,22 @@ ruleTester.run(RULE_NAME, rule, {
     'vi.fn(() => ({}))',
     'aVariable.mockImplementation',
     'aVariable.mockImplementation()',
+    {
+      code: 'jest.fn().mockImplementation(async () => 1);',
+      languageOptions: { parserOptions: { ecmaVersion: 2017 } },
+    },
+    {
+      code: 'jest.fn().mockImplementation(async function () {});',
+      languageOptions: { parserOptions: { ecmaVersion: 2017 } },
+    },
+    {
+      code: `
+        jest.fn().mockImplementation(async function () {
+          return 42;
+        });
+      `,
+      languageOptions: { parserOptions: { ecmaVersion: 2017 } },
+    },
     `
       aVariable.mockImplementation(() => {
         if (true) {
@@ -292,12 +308,14 @@ ruleTester.run(RULE_NAME, rule, {
       code: `
         aVariable
           .mockImplementation(() => 42)
+          .mockImplementation(async () => 42)
           .mockImplementation(() => Promise.resolve(42))
           .mockReturnValue("hello world")
       `.trim(),
       output: `
         aVariable
           .mockReturnValue(42)
+          .mockImplementation(async () => 42)
           .mockReturnValue(Promise.resolve(42))
           .mockReturnValue("hello world")
       `.trim(),
@@ -312,7 +330,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: 'useMockShorthand',
           data: { replacement: 'mockReturnValue' },
           column: 12,
-          line: 3,
+          line: 4,
         },
       ],
     },


### PR DESCRIPTION
This is a port of https://github.com/jest-community/eslint-plugin-jest/pull/1912