### PR TITLE
fix: correct package entrypoints for 1.6.8 dist output

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,15 @@
   "author": "Verite Mugabo <https://veritemugabo.com/>",
   "type": "module",
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
This patch fixes broken package entrypoints in v1.6.8.

Root cause:
- Introduced in commit 73a7184 (chore: bump up deps #871).
- tsdown was upgraded from ^0.15.10 to ^0.20.3.
- Build output changed from index.js/index.d.ts to index.mjs/index.d.mts, but package.json still pointed to index.js/index.d.ts.

Changes:
- module -> ./dist/index.mjs
- types -> ./dist/index.d.mts
- exports["."].import -> ./dist/index.mjs
- exports["."].types.import -> ./dist/index.d.mts
- exports["."].types.require -> ./dist/index.d.cts

Verification:
- pnpm build
- pnpm typecheck
- pnpm test
- npm pack confirms all referenced files are present