### PR TITLE
refactor: simplify ParsedGeneralVitestFnCall type exclusion

### DIFF
--- a/src/utils/parse-vitest-fn-call.ts
+++ b/src/utils/parse-vitest-fn-call.ts
@@ -67,7 +67,7 @@ interface BaseParsedVitestFnCall {
 }
 
 interface ParsedGeneralVitestFnCall extends BaseParsedVitestFnCall {
-  type: Exclude<VitestFnType, 'expect'> & Exclude<VitestFnType, 'expectTypeOf'>
+  type: Exclude<VitestFnType, 'expect' | 'expectTypeOf'>
 }
 
 type Reason = 'matcher-not-called' | 'modifier-unknown' | 'matcher-not-found'


### PR DESCRIPTION
I think `Exclude<VitestFnType, 'expect' | 'expectTypeOf'>` might be easier to read than intersecting two separate `Exclude` types.