### PR TITLE
fix(valid-expect): treat .finally() as part of async assertion promise chains

### DIFF
--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -74,7 +74,9 @@ function getParentIfThenified(node: TSESTree.Node): TSESTree.Node {
     grandParentNode.type === AST_NODE_TYPES.CallExpression &&
     grandParentNode.callee.type === AST_NODE_TYPES.MemberExpression &&
     isSupportedAccessor(grandParentNode.callee.property) &&
-    ['then', 'catch'].includes(
+    // .finally() returns the same promise the chain awaits, so the await still
+    // propagates and the inner expect-call must not be flagged again.
+    ['then', 'catch', 'finally'].includes(
       getAccessorValue(grandParentNode.callee.property),
     ) &&
     grandParentNode.parent

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -1,10 +1,10 @@
 import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils'
 import {
-  createEslintRule,
-  FunctionExpression,
-  getAccessorValue,
-  isFunction,
-  isSupportedAccessor,
+	createEslintRule,
+	FunctionExpression,
+	getAccessorValue,
+	isFunction,
+	isSupportedAccessor,
 } from '../utils'
 import { parseVitestFnCallWithReason } from '../utils/parse-vitest-fn-call'
 import { ModifierName } from '../utils/types'
@@ -12,13 +12,13 @@ import { parsePluginSettings } from '../utils/parse-plugin-settings'
 
 const RULE_NAME = 'valid-expect'
 export type MESSAGE_IDS =
-  | 'tooManyArgs'
-  | 'notEnoughArgs'
-  | 'modifierUnknown'
-  | 'matcherNotFound'
-  | 'matcherNotCalled'
-  | 'asyncMustBeAwaited'
-  | 'promisesWithAsyncAssertionsMustBeAwaited'
+	| 'tooManyArgs'
+	| 'notEnoughArgs'
+	| 'modifierUnknown'
+	| 'matcherNotFound'
+	| 'matcherNotCalled'
+	| 'asyncMustBeAwaited'
+	| 'promisesWithAsyncAssertionsMustBeAwaited'
 
 const defaultAsyncMatchers = ['toReject', 'toResolve']
 
@@ -30,406 +30,404 @@ const defaultAsyncMatchers = ['toReject', 'toResolve']
  * @Returns CallExpressionNode
  */
 const getPromiseCallExpressionNode = (node: TSESTree.Node) => {
-  if (
-    node.type === AST_NODE_TYPES.ArrayExpression &&
-    node.parent &&
-    node.parent.type === AST_NODE_TYPES.CallExpression
-  )
-    node = node.parent
+	if (
+		node.type === AST_NODE_TYPES.ArrayExpression &&
+		node.parent &&
+		node.parent.type === AST_NODE_TYPES.CallExpression
+	)
+		node = node.parent
 
-  if (
-    node.type === AST_NODE_TYPES.CallExpression &&
-    node.callee.type === AST_NODE_TYPES.MemberExpression &&
-    isSupportedAccessor(node.callee.object, 'Promise') &&
-    node.parent
-  )
-    return node
+	if (
+		node.type === AST_NODE_TYPES.CallExpression &&
+		node.callee.type === AST_NODE_TYPES.MemberExpression &&
+		isSupportedAccessor(node.callee.object, 'Promise') &&
+		node.parent
+	)
+		return node
 
-  return null
+	return null
 }
 
 const promiseArrayExceptionKey = ({ start, end }: TSESTree.SourceLocation) =>
-  `${start.line}:${start.column}-${end.line}:${end.column}`
+	`${start.line}:${start.column}-${end.line}:${end.column}`
 
 const getNormalizeFunctionExpression = (
-  functionExpression: FunctionExpression,
+	functionExpression: FunctionExpression,
 ):
-  | TSESTree.PropertyComputedName
-  | TSESTree.PropertyNonComputedName
-  | FunctionExpression => {
-  if (
-    functionExpression.parent.type === AST_NODE_TYPES.Property &&
-    functionExpression.type === AST_NODE_TYPES.FunctionExpression
-  )
-    return functionExpression.parent
+	| TSESTree.PropertyComputedName
+	| TSESTree.PropertyNonComputedName
+	| FunctionExpression => {
+	if (
+		functionExpression.parent.type === AST_NODE_TYPES.Property &&
+		functionExpression.type === AST_NODE_TYPES.FunctionExpression
+	)
+		return functionExpression.parent
 
-  return functionExpression
+	return functionExpression
 }
 
 function getParentIfThenified(node: TSESTree.Node): TSESTree.Node {
-  const grandParentNode = node.parent?.parent
+	const grandParentNode = node.parent?.parent
 
-  if (
-    grandParentNode &&
-    grandParentNode.type === AST_NODE_TYPES.CallExpression &&
-    grandParentNode.callee.type === AST_NODE_TYPES.MemberExpression &&
-    isSupportedAccessor(grandParentNode.callee.property) &&
-    // .finally() returns the same promise the chain awaits, so the await still
-    // propagates and the inner expect-call must not be flagged again.
-    ['then', 'catch', 'finally'].includes(
-      getAccessorValue(grandParentNode.callee.property),
-    ) &&
-    grandParentNode.parent
-  )
-    return getParentIfThenified(grandParentNode)
+	if (
+		grandParentNode &&
+		grandParentNode.type === AST_NODE_TYPES.CallExpression &&
+		grandParentNode.callee.type === AST_NODE_TYPES.MemberExpression &&
+		isSupportedAccessor(grandParentNode.callee.property) &&
+		['then', 'catch', 'finally'].includes(
+			getAccessorValue(grandParentNode.callee.property),
+		) &&
+		grandParentNode.parent
+	)
+		return getParentIfThenified(grandParentNode)
 
-  return node
+	return node
 }
 
 const findPromiseCallExpressionNode = (node: TSESTree.Node) =>
-  node.parent?.parent &&
-  [AST_NODE_TYPES.CallExpression, AST_NODE_TYPES.ArrayExpression].includes(
-    node.parent.type,
-  )
-    ? getPromiseCallExpressionNode(node.parent)
-    : null
+	node.parent?.parent &&
+		[AST_NODE_TYPES.CallExpression, AST_NODE_TYPES.ArrayExpression].includes(
+			node.parent.type,
+		)
+		? getPromiseCallExpressionNode(node.parent)
+		: null
 
 const findFirstFunctionExpression = ({
-  parent,
+	parent,
 }: TSESTree.Node): FunctionExpression | null => {
-  if (!parent) return null
+	if (!parent) return null
 
-  return isFunction(parent) ? parent : findFirstFunctionExpression(parent)
+	return isFunction(parent) ? parent : findFirstFunctionExpression(parent)
 }
 
 const isAcceptableReturnNode = (
-  node: TSESTree.Node,
-  allowReturn: boolean,
+	node: TSESTree.Node,
+	allowReturn: boolean,
 ): node is
-  | TSESTree.ConditionalExpression
-  | TSESTree.ArrowFunctionExpression
-  | TSESTree.AwaitExpression
-  | TSESTree.ReturnStatement => {
-  if (allowReturn && node.type === AST_NODE_TYPES.ReturnStatement) return true
+	| TSESTree.ConditionalExpression
+	| TSESTree.ArrowFunctionExpression
+	| TSESTree.AwaitExpression
+	| TSESTree.ReturnStatement => {
+	if (allowReturn && node.type === AST_NODE_TYPES.ReturnStatement) return true
 
-  if (node.type === AST_NODE_TYPES.ConditionalExpression && node.parent)
-    return isAcceptableReturnNode(node.parent, allowReturn)
+	if (node.type === AST_NODE_TYPES.ConditionalExpression && node.parent)
+		return isAcceptableReturnNode(node.parent, allowReturn)
 
-  return [
-    AST_NODE_TYPES.ArrowFunctionExpression,
-    AST_NODE_TYPES.AwaitExpression,
-  ].includes(node.type)
+	return [
+		AST_NODE_TYPES.ArrowFunctionExpression,
+		AST_NODE_TYPES.AwaitExpression,
+	].includes(node.type)
 }
 
 export default createEslintRule<
-  [
-    Partial<{
-      alwaysAwait: boolean
-      asyncMatchers: string[]
-      minArgs: number
-      maxArgs: number
-    }>,
-  ],
-  MESSAGE_IDS
+	[
+		Partial<{
+			alwaysAwait: boolean
+			asyncMatchers: string[]
+			minArgs: number
+			maxArgs: number
+		}>,
+	],
+	MESSAGE_IDS
 >({
-  name: RULE_NAME,
-  meta: {
-    docs: {
-      description: 'enforce valid `expect()` usage',
-      recommended: false,
-    },
-    messages: {
-      tooManyArgs: 'Expect takes at most {{ amount}} argument{{ s }}',
-      notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
-      modifierUnknown: 'Expect has an unknown modifier',
-      matcherNotFound: 'Expect must have a corresponding matcher call',
-      matcherNotCalled: 'Matchers must be called to assert',
-      asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}',
-      promisesWithAsyncAssertionsMustBeAwaited:
-        'Promises which return async assertions must be awaited{{ orReturned }}',
-    },
-    type: 'suggestion',
-    fixable: 'code',
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          alwaysAwait: {
-            description: 'Require awaiting every async assertion.',
-            type: 'boolean',
-          },
-          asyncMatchers: {
-            description: 'Matchers that should be considered async assertions.',
-            type: 'array',
-            items: { type: 'string' },
-          },
-          minArgs: {
-            description: 'Minimum number of arguments allowed for `expect`.',
-            type: 'number',
-            minimum: 1,
-          },
-          maxArgs: {
-            description: 'Maximum number of arguments allowed for `expect`.',
-            type: 'number',
-            minimum: 1,
-          },
-        },
-        additionalProperties: false,
-      },
-    ],
-    defaultOptions: [
-      {
-        alwaysAwait: false,
-        asyncMatchers: defaultAsyncMatchers,
-        minArgs: 1,
-        maxArgs: 1,
-      },
-    ],
-  },
-  create: (
-    context,
-    [
-      {
-        alwaysAwait,
-        asyncMatchers = defaultAsyncMatchers,
-        minArgs = 1,
-        maxArgs = 1,
-      },
-    ],
-  ) => {
-    const arrayExceptions = new Set<string>()
-    const descriptors: Array<{
-      node: TSESTree.Node
-      messageId: Extract<
-        MESSAGE_IDS,
-        'asyncMustBeAwaited' | 'promisesWithAsyncAssertionsMustBeAwaited'
-      >
-    }> = []
+	name: RULE_NAME,
+	meta: {
+		docs: {
+			description: 'enforce valid `expect()` usage',
+			recommended: false,
+		},
+		messages: {
+			tooManyArgs: 'Expect takes at most {{ amount}} argument{{ s }}',
+			notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
+			modifierUnknown: 'Expect has an unknown modifier',
+			matcherNotFound: 'Expect must have a corresponding matcher call',
+			matcherNotCalled: 'Matchers must be called to assert',
+			asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}',
+			promisesWithAsyncAssertionsMustBeAwaited:
+				'Promises which return async assertions must be awaited{{ orReturned }}',
+		},
+		type: 'suggestion',
+		fixable: 'code',
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					alwaysAwait: {
+						description: 'Require awaiting every async assertion.',
+						type: 'boolean',
+					},
+					asyncMatchers: {
+						description: 'Matchers that should be considered async assertions.',
+						type: 'array',
+						items: { type: 'string' },
+					},
+					minArgs: {
+						description: 'Minimum number of arguments allowed for `expect`.',
+						type: 'number',
+						minimum: 1,
+					},
+					maxArgs: {
+						description: 'Maximum number of arguments allowed for `expect`.',
+						type: 'number',
+						minimum: 1,
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+		defaultOptions: [
+			{
+				alwaysAwait: false,
+				asyncMatchers: defaultAsyncMatchers,
+				minArgs: 1,
+				maxArgs: 1,
+			},
+		],
+	},
+	create: (
+		context,
+		[
+			{
+				alwaysAwait,
+				asyncMatchers = defaultAsyncMatchers,
+				minArgs = 1,
+				maxArgs = 1,
+			},
+		],
+	) => {
+		const arrayExceptions = new Set<string>()
+		const descriptors: Array<{
+			node: TSESTree.Node
+			messageId: Extract<
+				MESSAGE_IDS,
+				'asyncMustBeAwaited' | 'promisesWithAsyncAssertionsMustBeAwaited'
+			>
+		}> = []
 
-    const pushPromiseArrayException = (loc: TSESTree.SourceLocation) =>
-      arrayExceptions.add(promiseArrayExceptionKey(loc))
+		const pushPromiseArrayException = (loc: TSESTree.SourceLocation) =>
+			arrayExceptions.add(promiseArrayExceptionKey(loc))
 
-    /**
-     * Promise method that accepts an array of promises,
-     * (eg. Promise.all), will throw warnings for the each
-     * unawaited or non-returned promise. To avoid throwing
-     * multiple warnings, we check if there is a warning in
-     * the given location.
-     */
-    const promiseArrayExceptionExists = (loc: TSESTree.SourceLocation) =>
-      arrayExceptions.has(promiseArrayExceptionKey(loc))
+		/**
+		 * Promise method that accepts an array of promises,
+		 * (eg. Promise.all), will throw warnings for the each
+		 * unawaited or non-returned promise. To avoid throwing
+		 * multiple warnings, we check if there is a warning in
+		 * the given location.
+		 */
+		const promiseArrayExceptionExists = (loc: TSESTree.SourceLocation) =>
+			arrayExceptions.has(promiseArrayExceptionKey(loc))
 
-    const findTopMostMemberExpression = (
-      node: TSESTree.MemberExpression,
-    ): TSESTree.MemberExpression => {
-      let topMostMemberExpression = node
-      let { parent } = node
+		const findTopMostMemberExpression = (
+			node: TSESTree.MemberExpression,
+		): TSESTree.MemberExpression => {
+			let topMostMemberExpression = node
+			let { parent } = node
 
-      while (parent) {
-        if (parent.type !== AST_NODE_TYPES.MemberExpression) break
+			while (parent) {
+				if (parent.type !== AST_NODE_TYPES.MemberExpression) break
 
-        topMostMemberExpression = parent
-        parent = parent.parent
-      }
-      return topMostMemberExpression
-    }
+				topMostMemberExpression = parent
+				parent = parent.parent
+			}
+			return topMostMemberExpression
+		}
 
-    return {
-      CallExpression(node) {
-        const vitestFnCall = parseVitestFnCallWithReason(node, context)
-        const settings = parsePluginSettings(context.settings)
+		return {
+			CallExpression(node) {
+				const vitestFnCall = parseVitestFnCallWithReason(node, context)
+				const settings = parsePluginSettings(context.settings)
 
-        if (typeof vitestFnCall === 'string') {
-          const reportingNode =
-            node.parent?.type === AST_NODE_TYPES.MemberExpression
-              ? findTopMostMemberExpression(node.parent).property
-              : node
+				if (typeof vitestFnCall === 'string') {
+					const reportingNode =
+						node.parent?.type === AST_NODE_TYPES.MemberExpression
+							? findTopMostMemberExpression(node.parent).property
+							: node
 
-          if (vitestFnCall === 'matcher-not-found') {
-            context.report({
-              messageId: 'matcherNotFound',
-              node: reportingNode,
-            })
+					if (vitestFnCall === 'matcher-not-found') {
+						context.report({
+							messageId: 'matcherNotFound',
+							node: reportingNode,
+						})
 
-            return
-          }
+						return
+					}
 
-          if (vitestFnCall === 'matcher-not-called') {
-            context.report({
-              messageId:
-                isSupportedAccessor(reportingNode) &&
-                Object.prototype.hasOwnProperty.call(
-                  ModifierName,
-                  getAccessorValue(reportingNode),
-                )
-                  ? 'matcherNotFound'
-                  : 'matcherNotCalled',
-              node: reportingNode,
-            })
-          }
+					if (vitestFnCall === 'matcher-not-called') {
+						context.report({
+							messageId:
+								isSupportedAccessor(reportingNode) &&
+									Object.prototype.hasOwnProperty.call(
+										ModifierName,
+										getAccessorValue(reportingNode),
+									)
+									? 'matcherNotFound'
+									: 'matcherNotCalled',
+							node: reportingNode,
+						})
+					}
 
-          if (vitestFnCall === 'modifier-unknown') {
-            context.report({
-              messageId: 'modifierUnknown',
-              node: reportingNode,
-            })
-            return
-          }
-          return
-        } else if (
-          vitestFnCall?.type === 'expectTypeOf' &&
-          settings.typecheck
-        ) {
-          return
-        } else if (vitestFnCall?.type !== 'expect') {
-          return
-        } else if (
-          vitestFnCall.modifiers.some(
-            (mod) => mod.type === AST_NODE_TYPES.Identifier && mod.name == 'to',
-          )
-        ) {
-          return
-        }
+					if (vitestFnCall === 'modifier-unknown') {
+						context.report({
+							messageId: 'modifierUnknown',
+							node: reportingNode,
+						})
+						return
+					}
+					return
+				} else if (
+					vitestFnCall?.type === 'expectTypeOf' &&
+					settings.typecheck
+				) {
+					return
+				} else if (vitestFnCall?.type !== 'expect') {
+					return
+				} else if (
+					vitestFnCall.modifiers.some(
+						(mod) => mod.type === AST_NODE_TYPES.Identifier && mod.name == 'to',
+					)
+				) {
+					return
+				}
 
-        const { parent: expect } = vitestFnCall.head.node
+				const { parent: expect } = vitestFnCall.head.node
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) return
+				if (expect?.type !== AST_NODE_TYPES.CallExpression) return
 
-        if (expect.arguments.length < minArgs) {
-          const expectLength = getAccessorValue(vitestFnCall.head.node).length
+				if (expect.arguments.length < minArgs) {
+					const expectLength = getAccessorValue(vitestFnCall.head.node).length
 
-          const loc: TSESTree.SourceLocation = {
-            start: {
-              column: expect.loc.start.column + expectLength,
-              line: expect.loc.start.line,
-            },
-            end: {
-              column: expect.loc.start.column + expectLength + 1,
-              line: expect.loc.start.line,
-            },
-          }
+					const loc: TSESTree.SourceLocation = {
+						start: {
+							column: expect.loc.start.column + expectLength,
+							line: expect.loc.start.line,
+						},
+						end: {
+							column: expect.loc.start.column + expectLength + 1,
+							line: expect.loc.start.line,
+						},
+					}
 
-          context.report({
-            messageId: 'notEnoughArgs',
-            data: { amount: minArgs, s: minArgs === 1 ? '' : 's' },
-            node: expect,
-            loc,
-          })
-        }
+					context.report({
+						messageId: 'notEnoughArgs',
+						data: { amount: minArgs, s: minArgs === 1 ? '' : 's' },
+						node: expect,
+						loc,
+					})
+				}
 
-        if (expect.arguments.length > maxArgs) {
-          // if expect(value, "message") and expect(value, `${message}`), it is valid usage
-          // Note: 2nd argument should be string, not a variable in current implementation
-          if (expect.arguments.length === 2) {
-            //  expect(value, "string literal")
-            const isSecondArgString =
-              expect.arguments[1].type === AST_NODE_TYPES.Literal &&
-              typeof expect.arguments[1].value === 'string'
-            // expect(value, `template literal`)
-            const isSecondArgTemplateLiteral =
-              expect.arguments[1].type === AST_NODE_TYPES.TemplateLiteral
-            if (isSecondArgString || isSecondArgTemplateLiteral) {
-              return
-            }
-          }
+				if (expect.arguments.length > maxArgs) {
+					// if expect(value, "message") and expect(value, `${message}`), it is valid usage
+					// Note: 2nd argument should be string, not a variable in current implementation
+					if (expect.arguments.length === 2) {
+						//  expect(value, "string literal")
+						const isSecondArgString =
+							expect.arguments[1].type === AST_NODE_TYPES.Literal &&
+							typeof expect.arguments[1].value === 'string'
+						// expect(value, `template literal`)
+						const isSecondArgTemplateLiteral =
+							expect.arguments[1].type === AST_NODE_TYPES.TemplateLiteral
+						if (isSecondArgString || isSecondArgTemplateLiteral) {
+							return
+						}
+					}
 
-          const { start } = expect.arguments[maxArgs].loc
-          const { end } = expect.arguments[expect.arguments.length - 1].loc
+					const { start } = expect.arguments[maxArgs].loc
+					const { end } = expect.arguments[expect.arguments.length - 1].loc
 
-          const loc = {
-            start,
-            end: {
-              column: end.column + 1,
-              line: end.line,
-            },
-          }
+					const loc = {
+						start,
+						end: {
+							column: end.column + 1,
+							line: end.line,
+						},
+					}
 
-          context.report({
-            messageId: 'tooManyArgs',
-            data: { amount: maxArgs, s: maxArgs === 1 ? '' : 's' },
-            node: expect,
-            loc,
-          })
-        }
+					context.report({
+						messageId: 'tooManyArgs',
+						data: { amount: maxArgs, s: maxArgs === 1 ? '' : 's' },
+						node: expect,
+						loc,
+					})
+				}
 
-        const { matcher } = vitestFnCall
+				const { matcher } = vitestFnCall
 
-        const parentNode = matcher.parent.parent
-        const shouldBeAwaited =
-          vitestFnCall.modifiers.some(
-            (nod) => getAccessorValue(nod) !== 'not',
-          ) || asyncMatchers.includes(getAccessorValue(matcher))
+				const parentNode = matcher.parent.parent
+				const shouldBeAwaited =
+					vitestFnCall.modifiers.some(
+						(nod) => getAccessorValue(nod) !== 'not',
+					) || asyncMatchers.includes(getAccessorValue(matcher))
 
-        if (!parentNode?.parent || !shouldBeAwaited) return
+				if (!parentNode?.parent || !shouldBeAwaited) return
 
-        const isParentArrayExpression =
-          parentNode.parent.type === AST_NODE_TYPES.ArrayExpression
+				const isParentArrayExpression =
+					parentNode.parent.type === AST_NODE_TYPES.ArrayExpression
 
-        const targetNode = getParentIfThenified(parentNode)
-        const finalNode =
-          findPromiseCallExpressionNode(targetNode) || targetNode
+				const targetNode = getParentIfThenified(parentNode)
+				const finalNode =
+					findPromiseCallExpressionNode(targetNode) || targetNode
 
-        if (
-          finalNode.parent &&
-          !isAcceptableReturnNode(finalNode.parent, !alwaysAwait) &&
-          !promiseArrayExceptionExists(finalNode.loc)
-        ) {
-          descriptors.push({
-            messageId:
-              finalNode === targetNode
-                ? 'asyncMustBeAwaited'
-                : 'promisesWithAsyncAssertionsMustBeAwaited',
-            node: finalNode,
-          })
+				if (
+					finalNode.parent &&
+					!isAcceptableReturnNode(finalNode.parent, !alwaysAwait) &&
+					!promiseArrayExceptionExists(finalNode.loc)
+				) {
+					descriptors.push({
+						messageId:
+							finalNode === targetNode
+								? 'asyncMustBeAwaited'
+								: 'promisesWithAsyncAssertionsMustBeAwaited',
+						node: finalNode,
+					})
 
-          if (isParentArrayExpression) pushPromiseArrayException(finalNode.loc)
-        }
-      },
-      'Program:exit'() {
-        const fixes: TSESLint.RuleFix[] = []
+					if (isParentArrayExpression) pushPromiseArrayException(finalNode.loc)
+				}
+			},
+			'Program:exit'() {
+				const fixes: TSESLint.RuleFix[] = []
 
-        descriptors.forEach(({ node, messageId }, index) => {
-          const orReturned = alwaysAwait ? '' : ' or returned'
+				descriptors.forEach(({ node, messageId }, index) => {
+					const orReturned = alwaysAwait ? '' : ' or returned'
 
-          context.report({
-            loc: node.loc,
-            data: { orReturned },
-            messageId,
-            node,
-            fix(fixer) {
-              const functionExpression = findFirstFunctionExpression(node)
+					context.report({
+						loc: node.loc,
+						data: { orReturned },
+						messageId,
+						node,
+						fix(fixer) {
+							const functionExpression = findFirstFunctionExpression(node)
 
-              if (!functionExpression) return null
+							if (!functionExpression) return null
 
-              const foundAsyncFixer = fixes.some((fix) => fix.text === 'async ')
+							const foundAsyncFixer = fixes.some((fix) => fix.text === 'async ')
 
-              if (!functionExpression.async && !foundAsyncFixer) {
-                const targetFunction =
-                  getNormalizeFunctionExpression(functionExpression)
+							if (!functionExpression.async && !foundAsyncFixer) {
+								const targetFunction =
+									getNormalizeFunctionExpression(functionExpression)
 
-                fixes.push(fixer.insertTextBefore(targetFunction, 'async '))
-              }
+								fixes.push(fixer.insertTextBefore(targetFunction, 'async '))
+							}
 
-              const returnStatement =
-                node.parent?.type === AST_NODE_TYPES.ReturnStatement
-                  ? node.parent
-                  : null
+							const returnStatement =
+								node.parent?.type === AST_NODE_TYPES.ReturnStatement
+									? node.parent
+									: null
 
-              if (alwaysAwait && returnStatement) {
-                const sourceCodeText =
-                  context.sourceCode.getText(returnStatement)
-                const replacedText = sourceCodeText.replace('return', 'await')
+							if (alwaysAwait && returnStatement) {
+								const sourceCodeText =
+									context.sourceCode.getText(returnStatement)
+								const replacedText = sourceCodeText.replace('return', 'await')
 
-                fixes.push(fixer.replaceText(returnStatement, replacedText))
-              } else {
-                fixes.push(fixer.insertTextBefore(node, 'await '))
-              }
+								fixes.push(fixer.replaceText(returnStatement, replacedText))
+							} else {
+								fixes.push(fixer.insertTextBefore(node, 'await '))
+							}
 
-              return index === descriptors.length - 1 ? fixes : null
-            },
-          })
-        })
-      },
-    }
-  },
+							return index === descriptors.length - 1 ? fixes : null
+						},
+					})
+				})
+			},
+		}
+	},
 })

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -1,10 +1,10 @@
 import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils'
 import {
-	createEslintRule,
-	FunctionExpression,
-	getAccessorValue,
-	isFunction,
-	isSupportedAccessor,
+  createEslintRule,
+  FunctionExpression,
+  getAccessorValue,
+  isFunction,
+  isSupportedAccessor,
 } from '../utils'
 import { parseVitestFnCallWithReason } from '../utils/parse-vitest-fn-call'
 import { ModifierName } from '../utils/types'
@@ -12,13 +12,13 @@ import { parsePluginSettings } from '../utils/parse-plugin-settings'
 
 const RULE_NAME = 'valid-expect'
 export type MESSAGE_IDS =
-	| 'tooManyArgs'
-	| 'notEnoughArgs'
-	| 'modifierUnknown'
-	| 'matcherNotFound'
-	| 'matcherNotCalled'
-	| 'asyncMustBeAwaited'
-	| 'promisesWithAsyncAssertionsMustBeAwaited'
+  | 'tooManyArgs'
+  | 'notEnoughArgs'
+  | 'modifierUnknown'
+  | 'matcherNotFound'
+  | 'matcherNotCalled'
+  | 'asyncMustBeAwaited'
+  | 'promisesWithAsyncAssertionsMustBeAwaited'
 
 const defaultAsyncMatchers = ['toReject', 'toResolve']
 
@@ -30,404 +30,404 @@ const defaultAsyncMatchers = ['toReject', 'toResolve']
  * @Returns CallExpressionNode
  */
 const getPromiseCallExpressionNode = (node: TSESTree.Node) => {
-	if (
-		node.type === AST_NODE_TYPES.ArrayExpression &&
-		node.parent &&
-		node.parent.type === AST_NODE_TYPES.CallExpression
-	)
-		node = node.parent
+  if (
+    node.type === AST_NODE_TYPES.ArrayExpression &&
+    node.parent &&
+    node.parent.type === AST_NODE_TYPES.CallExpression
+  )
+    node = node.parent
 
-	if (
-		node.type === AST_NODE_TYPES.CallExpression &&
-		node.callee.type === AST_NODE_TYPES.MemberExpression &&
-		isSupportedAccessor(node.callee.object, 'Promise') &&
-		node.parent
-	)
-		return node
+  if (
+    node.type === AST_NODE_TYPES.CallExpression &&
+    node.callee.type === AST_NODE_TYPES.MemberExpression &&
+    isSupportedAccessor(node.callee.object, 'Promise') &&
+    node.parent
+  )
+    return node
 
-	return null
+  return null
 }
 
 const promiseArrayExceptionKey = ({ start, end }: TSESTree.SourceLocation) =>
-	`${start.line}:${start.column}-${end.line}:${end.column}`
+  `${start.line}:${start.column}-${end.line}:${end.column}`
 
 const getNormalizeFunctionExpression = (
-	functionExpression: FunctionExpression,
+  functionExpression: FunctionExpression,
 ):
-	| TSESTree.PropertyComputedName
-	| TSESTree.PropertyNonComputedName
-	| FunctionExpression => {
-	if (
-		functionExpression.parent.type === AST_NODE_TYPES.Property &&
-		functionExpression.type === AST_NODE_TYPES.FunctionExpression
-	)
-		return functionExpression.parent
+  | TSESTree.PropertyComputedName
+  | TSESTree.PropertyNonComputedName
+  | FunctionExpression => {
+  if (
+    functionExpression.parent.type === AST_NODE_TYPES.Property &&
+    functionExpression.type === AST_NODE_TYPES.FunctionExpression
+  )
+    return functionExpression.parent
 
-	return functionExpression
+  return functionExpression
 }
 
 function getParentIfThenified(node: TSESTree.Node): TSESTree.Node {
-	const grandParentNode = node.parent?.parent
+  const grandParentNode = node.parent?.parent
 
-	if (
-		grandParentNode &&
-		grandParentNode.type === AST_NODE_TYPES.CallExpression &&
-		grandParentNode.callee.type === AST_NODE_TYPES.MemberExpression &&
-		isSupportedAccessor(grandParentNode.callee.property) &&
-		['then', 'catch', 'finally'].includes(
-			getAccessorValue(grandParentNode.callee.property),
-		) &&
-		grandParentNode.parent
-	)
-		return getParentIfThenified(grandParentNode)
+  if (
+    grandParentNode &&
+    grandParentNode.type === AST_NODE_TYPES.CallExpression &&
+    grandParentNode.callee.type === AST_NODE_TYPES.MemberExpression &&
+    isSupportedAccessor(grandParentNode.callee.property) &&
+    ['then', 'catch', 'finally'].includes(
+      getAccessorValue(grandParentNode.callee.property),
+    ) &&
+    grandParentNode.parent
+  )
+    return getParentIfThenified(grandParentNode)
 
-	return node
+  return node
 }
 
 const findPromiseCallExpressionNode = (node: TSESTree.Node) =>
-	node.parent?.parent &&
-		[AST_NODE_TYPES.CallExpression, AST_NODE_TYPES.ArrayExpression].includes(
-			node.parent.type,
-		)
-		? getPromiseCallExpressionNode(node.parent)
-		: null
+  node.parent?.parent &&
+  [AST_NODE_TYPES.CallExpression, AST_NODE_TYPES.ArrayExpression].includes(
+    node.parent.type,
+  )
+    ? getPromiseCallExpressionNode(node.parent)
+    : null
 
 const findFirstFunctionExpression = ({
-	parent,
+  parent,
 }: TSESTree.Node): FunctionExpression | null => {
-	if (!parent) return null
+  if (!parent) return null
 
-	return isFunction(parent) ? parent : findFirstFunctionExpression(parent)
+  return isFunction(parent) ? parent : findFirstFunctionExpression(parent)
 }
 
 const isAcceptableReturnNode = (
-	node: TSESTree.Node,
-	allowReturn: boolean,
+  node: TSESTree.Node,
+  allowReturn: boolean,
 ): node is
-	| TSESTree.ConditionalExpression
-	| TSESTree.ArrowFunctionExpression
-	| TSESTree.AwaitExpression
-	| TSESTree.ReturnStatement => {
-	if (allowReturn && node.type === AST_NODE_TYPES.ReturnStatement) return true
+  | TSESTree.ConditionalExpression
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.AwaitExpression
+  | TSESTree.ReturnStatement => {
+  if (allowReturn && node.type === AST_NODE_TYPES.ReturnStatement) return true
 
-	if (node.type === AST_NODE_TYPES.ConditionalExpression && node.parent)
-		return isAcceptableReturnNode(node.parent, allowReturn)
+  if (node.type === AST_NODE_TYPES.ConditionalExpression && node.parent)
+    return isAcceptableReturnNode(node.parent, allowReturn)
 
-	return [
-		AST_NODE_TYPES.ArrowFunctionExpression,
-		AST_NODE_TYPES.AwaitExpression,
-	].includes(node.type)
+  return [
+    AST_NODE_TYPES.ArrowFunctionExpression,
+    AST_NODE_TYPES.AwaitExpression,
+  ].includes(node.type)
 }
 
 export default createEslintRule<
-	[
-		Partial<{
-			alwaysAwait: boolean
-			asyncMatchers: string[]
-			minArgs: number
-			maxArgs: number
-		}>,
-	],
-	MESSAGE_IDS
+  [
+    Partial<{
+      alwaysAwait: boolean
+      asyncMatchers: string[]
+      minArgs: number
+      maxArgs: number
+    }>,
+  ],
+  MESSAGE_IDS
 >({
-	name: RULE_NAME,
-	meta: {
-		docs: {
-			description: 'enforce valid `expect()` usage',
-			recommended: false,
-		},
-		messages: {
-			tooManyArgs: 'Expect takes at most {{ amount}} argument{{ s }}',
-			notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
-			modifierUnknown: 'Expect has an unknown modifier',
-			matcherNotFound: 'Expect must have a corresponding matcher call',
-			matcherNotCalled: 'Matchers must be called to assert',
-			asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}',
-			promisesWithAsyncAssertionsMustBeAwaited:
-				'Promises which return async assertions must be awaited{{ orReturned }}',
-		},
-		type: 'suggestion',
-		fixable: 'code',
-		schema: [
-			{
-				type: 'object',
-				properties: {
-					alwaysAwait: {
-						description: 'Require awaiting every async assertion.',
-						type: 'boolean',
-					},
-					asyncMatchers: {
-						description: 'Matchers that should be considered async assertions.',
-						type: 'array',
-						items: { type: 'string' },
-					},
-					minArgs: {
-						description: 'Minimum number of arguments allowed for `expect`.',
-						type: 'number',
-						minimum: 1,
-					},
-					maxArgs: {
-						description: 'Maximum number of arguments allowed for `expect`.',
-						type: 'number',
-						minimum: 1,
-					},
-				},
-				additionalProperties: false,
-			},
-		],
-		defaultOptions: [
-			{
-				alwaysAwait: false,
-				asyncMatchers: defaultAsyncMatchers,
-				minArgs: 1,
-				maxArgs: 1,
-			},
-		],
-	},
-	create: (
-		context,
-		[
-			{
-				alwaysAwait,
-				asyncMatchers = defaultAsyncMatchers,
-				minArgs = 1,
-				maxArgs = 1,
-			},
-		],
-	) => {
-		const arrayExceptions = new Set<string>()
-		const descriptors: Array<{
-			node: TSESTree.Node
-			messageId: Extract<
-				MESSAGE_IDS,
-				'asyncMustBeAwaited' | 'promisesWithAsyncAssertionsMustBeAwaited'
-			>
-		}> = []
+  name: RULE_NAME,
+  meta: {
+    docs: {
+      description: 'enforce valid `expect()` usage',
+      recommended: false,
+    },
+    messages: {
+      tooManyArgs: 'Expect takes at most {{ amount}} argument{{ s }}',
+      notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
+      modifierUnknown: 'Expect has an unknown modifier',
+      matcherNotFound: 'Expect must have a corresponding matcher call',
+      matcherNotCalled: 'Matchers must be called to assert',
+      asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}',
+      promisesWithAsyncAssertionsMustBeAwaited:
+        'Promises which return async assertions must be awaited{{ orReturned }}',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          alwaysAwait: {
+            description: 'Require awaiting every async assertion.',
+            type: 'boolean',
+          },
+          asyncMatchers: {
+            description: 'Matchers that should be considered async assertions.',
+            type: 'array',
+            items: { type: 'string' },
+          },
+          minArgs: {
+            description: 'Minimum number of arguments allowed for `expect`.',
+            type: 'number',
+            minimum: 1,
+          },
+          maxArgs: {
+            description: 'Maximum number of arguments allowed for `expect`.',
+            type: 'number',
+            minimum: 1,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [
+      {
+        alwaysAwait: false,
+        asyncMatchers: defaultAsyncMatchers,
+        minArgs: 1,
+        maxArgs: 1,
+      },
+    ],
+  },
+  create: (
+    context,
+    [
+      {
+        alwaysAwait,
+        asyncMatchers = defaultAsyncMatchers,
+        minArgs = 1,
+        maxArgs = 1,
+      },
+    ],
+  ) => {
+    const arrayExceptions = new Set<string>()
+    const descriptors: Array<{
+      node: TSESTree.Node
+      messageId: Extract<
+        MESSAGE_IDS,
+        'asyncMustBeAwaited' | 'promisesWithAsyncAssertionsMustBeAwaited'
+      >
+    }> = []
 
-		const pushPromiseArrayException = (loc: TSESTree.SourceLocation) =>
-			arrayExceptions.add(promiseArrayExceptionKey(loc))
+    const pushPromiseArrayException = (loc: TSESTree.SourceLocation) =>
+      arrayExceptions.add(promiseArrayExceptionKey(loc))
 
-		/**
-		 * Promise method that accepts an array of promises,
-		 * (eg. Promise.all), will throw warnings for the each
-		 * unawaited or non-returned promise. To avoid throwing
-		 * multiple warnings, we check if there is a warning in
-		 * the given location.
-		 */
-		const promiseArrayExceptionExists = (loc: TSESTree.SourceLocation) =>
-			arrayExceptions.has(promiseArrayExceptionKey(loc))
+    /**
+     * Promise method that accepts an array of promises,
+     * (eg. Promise.all), will throw warnings for the each
+     * unawaited or non-returned promise. To avoid throwing
+     * multiple warnings, we check if there is a warning in
+     * the given location.
+     */
+    const promiseArrayExceptionExists = (loc: TSESTree.SourceLocation) =>
+      arrayExceptions.has(promiseArrayExceptionKey(loc))
 
-		const findTopMostMemberExpression = (
-			node: TSESTree.MemberExpression,
-		): TSESTree.MemberExpression => {
-			let topMostMemberExpression = node
-			let { parent } = node
+    const findTopMostMemberExpression = (
+      node: TSESTree.MemberExpression,
+    ): TSESTree.MemberExpression => {
+      let topMostMemberExpression = node
+      let { parent } = node
 
-			while (parent) {
-				if (parent.type !== AST_NODE_TYPES.MemberExpression) break
+      while (parent) {
+        if (parent.type !== AST_NODE_TYPES.MemberExpression) break
 
-				topMostMemberExpression = parent
-				parent = parent.parent
-			}
-			return topMostMemberExpression
-		}
+        topMostMemberExpression = parent
+        parent = parent.parent
+      }
+      return topMostMemberExpression
+    }
 
-		return {
-			CallExpression(node) {
-				const vitestFnCall = parseVitestFnCallWithReason(node, context)
-				const settings = parsePluginSettings(context.settings)
+    return {
+      CallExpression(node) {
+        const vitestFnCall = parseVitestFnCallWithReason(node, context)
+        const settings = parsePluginSettings(context.settings)
 
-				if (typeof vitestFnCall === 'string') {
-					const reportingNode =
-						node.parent?.type === AST_NODE_TYPES.MemberExpression
-							? findTopMostMemberExpression(node.parent).property
-							: node
+        if (typeof vitestFnCall === 'string') {
+          const reportingNode =
+            node.parent?.type === AST_NODE_TYPES.MemberExpression
+              ? findTopMostMemberExpression(node.parent).property
+              : node
 
-					if (vitestFnCall === 'matcher-not-found') {
-						context.report({
-							messageId: 'matcherNotFound',
-							node: reportingNode,
-						})
+          if (vitestFnCall === 'matcher-not-found') {
+            context.report({
+              messageId: 'matcherNotFound',
+              node: reportingNode,
+            })
 
-						return
-					}
+            return
+          }
 
-					if (vitestFnCall === 'matcher-not-called') {
-						context.report({
-							messageId:
-								isSupportedAccessor(reportingNode) &&
-									Object.prototype.hasOwnProperty.call(
-										ModifierName,
-										getAccessorValue(reportingNode),
-									)
-									? 'matcherNotFound'
-									: 'matcherNotCalled',
-							node: reportingNode,
-						})
-					}
+          if (vitestFnCall === 'matcher-not-called') {
+            context.report({
+              messageId:
+                isSupportedAccessor(reportingNode) &&
+                Object.prototype.hasOwnProperty.call(
+                  ModifierName,
+                  getAccessorValue(reportingNode),
+                )
+                  ? 'matcherNotFound'
+                  : 'matcherNotCalled',
+              node: reportingNode,
+            })
+          }
 
-					if (vitestFnCall === 'modifier-unknown') {
-						context.report({
-							messageId: 'modifierUnknown',
-							node: reportingNode,
-						})
-						return
-					}
-					return
-				} else if (
-					vitestFnCall?.type === 'expectTypeOf' &&
-					settings.typecheck
-				) {
-					return
-				} else if (vitestFnCall?.type !== 'expect') {
-					return
-				} else if (
-					vitestFnCall.modifiers.some(
-						(mod) => mod.type === AST_NODE_TYPES.Identifier && mod.name == 'to',
-					)
-				) {
-					return
-				}
+          if (vitestFnCall === 'modifier-unknown') {
+            context.report({
+              messageId: 'modifierUnknown',
+              node: reportingNode,
+            })
+            return
+          }
+          return
+        } else if (
+          vitestFnCall?.type === 'expectTypeOf' &&
+          settings.typecheck
+        ) {
+          return
+        } else if (vitestFnCall?.type !== 'expect') {
+          return
+        } else if (
+          vitestFnCall.modifiers.some(
+            (mod) => mod.type === AST_NODE_TYPES.Identifier && mod.name == 'to',
+          )
+        ) {
+          return
+        }
 
-				const { parent: expect } = vitestFnCall.head.node
+        const { parent: expect } = vitestFnCall.head.node
 
-				if (expect?.type !== AST_NODE_TYPES.CallExpression) return
+        if (expect?.type !== AST_NODE_TYPES.CallExpression) return
 
-				if (expect.arguments.length < minArgs) {
-					const expectLength = getAccessorValue(vitestFnCall.head.node).length
+        if (expect.arguments.length < minArgs) {
+          const expectLength = getAccessorValue(vitestFnCall.head.node).length
 
-					const loc: TSESTree.SourceLocation = {
-						start: {
-							column: expect.loc.start.column + expectLength,
-							line: expect.loc.start.line,
-						},
-						end: {
-							column: expect.loc.start.column + expectLength + 1,
-							line: expect.loc.start.line,
-						},
-					}
+          const loc: TSESTree.SourceLocation = {
+            start: {
+              column: expect.loc.start.column + expectLength,
+              line: expect.loc.start.line,
+            },
+            end: {
+              column: expect.loc.start.column + expectLength + 1,
+              line: expect.loc.start.line,
+            },
+          }
 
-					context.report({
-						messageId: 'notEnoughArgs',
-						data: { amount: minArgs, s: minArgs === 1 ? '' : 's' },
-						node: expect,
-						loc,
-					})
-				}
+          context.report({
+            messageId: 'notEnoughArgs',
+            data: { amount: minArgs, s: minArgs === 1 ? '' : 's' },
+            node: expect,
+            loc,
+          })
+        }
 
-				if (expect.arguments.length > maxArgs) {
-					// if expect(value, "message") and expect(value, `${message}`), it is valid usage
-					// Note: 2nd argument should be string, not a variable in current implementation
-					if (expect.arguments.length === 2) {
-						//  expect(value, "string literal")
-						const isSecondArgString =
-							expect.arguments[1].type === AST_NODE_TYPES.Literal &&
-							typeof expect.arguments[1].value === 'string'
-						// expect(value, `template literal`)
-						const isSecondArgTemplateLiteral =
-							expect.arguments[1].type === AST_NODE_TYPES.TemplateLiteral
-						if (isSecondArgString || isSecondArgTemplateLiteral) {
-							return
-						}
-					}
+        if (expect.arguments.length > maxArgs) {
+          // if expect(value, "message") and expect(value, `${message}`), it is valid usage
+          // Note: 2nd argument should be string, not a variable in current implementation
+          if (expect.arguments.length === 2) {
+            //  expect(value, "string literal")
+            const isSecondArgString =
+              expect.arguments[1].type === AST_NODE_TYPES.Literal &&
+              typeof expect.arguments[1].value === 'string'
+            // expect(value, `template literal`)
+            const isSecondArgTemplateLiteral =
+              expect.arguments[1].type === AST_NODE_TYPES.TemplateLiteral
+            if (isSecondArgString || isSecondArgTemplateLiteral) {
+              return
+            }
+          }
 
-					const { start } = expect.arguments[maxArgs].loc
-					const { end } = expect.arguments[expect.arguments.length - 1].loc
+          const { start } = expect.arguments[maxArgs].loc
+          const { end } = expect.arguments[expect.arguments.length - 1].loc
 
-					const loc = {
-						start,
-						end: {
-							column: end.column + 1,
-							line: end.line,
-						},
-					}
+          const loc = {
+            start,
+            end: {
+              column: end.column + 1,
+              line: end.line,
+            },
+          }
 
-					context.report({
-						messageId: 'tooManyArgs',
-						data: { amount: maxArgs, s: maxArgs === 1 ? '' : 's' },
-						node: expect,
-						loc,
-					})
-				}
+          context.report({
+            messageId: 'tooManyArgs',
+            data: { amount: maxArgs, s: maxArgs === 1 ? '' : 's' },
+            node: expect,
+            loc,
+          })
+        }
 
-				const { matcher } = vitestFnCall
+        const { matcher } = vitestFnCall
 
-				const parentNode = matcher.parent.parent
-				const shouldBeAwaited =
-					vitestFnCall.modifiers.some(
-						(nod) => getAccessorValue(nod) !== 'not',
-					) || asyncMatchers.includes(getAccessorValue(matcher))
+        const parentNode = matcher.parent.parent
+        const shouldBeAwaited =
+          vitestFnCall.modifiers.some(
+            (nod) => getAccessorValue(nod) !== 'not',
+          ) || asyncMatchers.includes(getAccessorValue(matcher))
 
-				if (!parentNode?.parent || !shouldBeAwaited) return
+        if (!parentNode?.parent || !shouldBeAwaited) return
 
-				const isParentArrayExpression =
-					parentNode.parent.type === AST_NODE_TYPES.ArrayExpression
+        const isParentArrayExpression =
+          parentNode.parent.type === AST_NODE_TYPES.ArrayExpression
 
-				const targetNode = getParentIfThenified(parentNode)
-				const finalNode =
-					findPromiseCallExpressionNode(targetNode) || targetNode
+        const targetNode = getParentIfThenified(parentNode)
+        const finalNode =
+          findPromiseCallExpressionNode(targetNode) || targetNode
 
-				if (
-					finalNode.parent &&
-					!isAcceptableReturnNode(finalNode.parent, !alwaysAwait) &&
-					!promiseArrayExceptionExists(finalNode.loc)
-				) {
-					descriptors.push({
-						messageId:
-							finalNode === targetNode
-								? 'asyncMustBeAwaited'
-								: 'promisesWithAsyncAssertionsMustBeAwaited',
-						node: finalNode,
-					})
+        if (
+          finalNode.parent &&
+          !isAcceptableReturnNode(finalNode.parent, !alwaysAwait) &&
+          !promiseArrayExceptionExists(finalNode.loc)
+        ) {
+          descriptors.push({
+            messageId:
+              finalNode === targetNode
+                ? 'asyncMustBeAwaited'
+                : 'promisesWithAsyncAssertionsMustBeAwaited',
+            node: finalNode,
+          })
 
-					if (isParentArrayExpression) pushPromiseArrayException(finalNode.loc)
-				}
-			},
-			'Program:exit'() {
-				const fixes: TSESLint.RuleFix[] = []
+          if (isParentArrayExpression) pushPromiseArrayException(finalNode.loc)
+        }
+      },
+      'Program:exit'() {
+        const fixes: TSESLint.RuleFix[] = []
 
-				descriptors.forEach(({ node, messageId }, index) => {
-					const orReturned = alwaysAwait ? '' : ' or returned'
+        descriptors.forEach(({ node, messageId }, index) => {
+          const orReturned = alwaysAwait ? '' : ' or returned'
 
-					context.report({
-						loc: node.loc,
-						data: { orReturned },
-						messageId,
-						node,
-						fix(fixer) {
-							const functionExpression = findFirstFunctionExpression(node)
+          context.report({
+            loc: node.loc,
+            data: { orReturned },
+            messageId,
+            node,
+            fix(fixer) {
+              const functionExpression = findFirstFunctionExpression(node)
 
-							if (!functionExpression) return null
+              if (!functionExpression) return null
 
-							const foundAsyncFixer = fixes.some((fix) => fix.text === 'async ')
+              const foundAsyncFixer = fixes.some((fix) => fix.text === 'async ')
 
-							if (!functionExpression.async && !foundAsyncFixer) {
-								const targetFunction =
-									getNormalizeFunctionExpression(functionExpression)
+              if (!functionExpression.async && !foundAsyncFixer) {
+                const targetFunction =
+                  getNormalizeFunctionExpression(functionExpression)
 
-								fixes.push(fixer.insertTextBefore(targetFunction, 'async '))
-							}
+                fixes.push(fixer.insertTextBefore(targetFunction, 'async '))
+              }
 
-							const returnStatement =
-								node.parent?.type === AST_NODE_TYPES.ReturnStatement
-									? node.parent
-									: null
+              const returnStatement =
+                node.parent?.type === AST_NODE_TYPES.ReturnStatement
+                  ? node.parent
+                  : null
 
-							if (alwaysAwait && returnStatement) {
-								const sourceCodeText =
-									context.sourceCode.getText(returnStatement)
-								const replacedText = sourceCodeText.replace('return', 'await')
+              if (alwaysAwait && returnStatement) {
+                const sourceCodeText =
+                  context.sourceCode.getText(returnStatement)
+                const replacedText = sourceCodeText.replace('return', 'await')
 
-								fixes.push(fixer.replaceText(returnStatement, replacedText))
-							} else {
-								fixes.push(fixer.insertTextBefore(node, 'await '))
-							}
+                fixes.push(fixer.replaceText(returnStatement, replacedText))
+              } else {
+                fixes.push(fixer.insertTextBefore(node, 'await '))
+              }
 
-							return index === descriptors.length - 1 ? fixes : null
-						},
-					})
-				})
-			},
-		}
-	},
+              return index === descriptors.length - 1 ? fixes : null
+            },
+          })
+        })
+      },
+    }
+  },
 })

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -2,70 +2,70 @@ import rule from '../src/rules/valid-expect'
 import { ruleTester } from './ruleTester'
 
 ruleTester.run(rule.name, rule, {
-	valid: [
-		'expect.hasAssertions',
-		'expect.hasAssertions()',
-		'expect("something").toEqual("else");',
-		'expect(true).toBeDefined();',
-		'expect([1, 2, 3]).toEqual([1, 2, 3]);',
-		'expect(undefined).not.toBeDefined();',
-		'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-		'test("valid-expect", () => { return expect(Promise.reject(2)).rejects.toBeDefined(); });',
-		'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-		'test("valid-expect", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-		'test("valid-expect", function () { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-		'test("valid-expect", function () { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-		'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined()); });',
-		'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).rejects.not.toBeDefined()); });',
-		'test("valid-expect", () => expect(Promise.resolve(2)).resolves.toBeDefined());',
-		'test("valid-expect", () => expect(Promise.reject(2)).rejects.toBeDefined());',
-		'test("valid-expect", () => expect(Promise.reject(2)).resolves.not.toBeDefined());',
-		'test("valid-expect", () => expect(Promise.reject(2)).rejects.not.toBeDefined());',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
-		'test("valid-expect", async function () { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
-		'test("valid-expect", async function () { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
-		'test("valid-expect", async () => { await Promise.resolve(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
-		'test("valid-expect", async () => { await Promise.reject(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
-		'test("valid-expect", async () => { await Promise.all([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-		'test("valid-expect", async () => { await Promise.race([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-		'test("valid-expect", async () => { await Promise.allSettled([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-		'test("valid-expect", async () => { await Promise.any([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
-		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
-		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
-		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
-		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
-		'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("valid-case")); });',
-		'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")); });',
-		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")).then(() => console.log("after")); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined().finally(() => console.log("cleanup")); });',
-		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")).catch(() => console.log("recover")); });',
-		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup 1")).finally(() => console.log("cleanup 2")); });',
-		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("recover")).finally(() => console.log("cleanup")); });',
-		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
-		` test("valid-expect", () => {
+  valid: [
+    'expect.hasAssertions',
+    'expect.hasAssertions()',
+    'expect("something").toEqual("else");',
+    'expect(true).toBeDefined();',
+    'expect([1, 2, 3]).toEqual([1, 2, 3]);',
+    'expect(undefined).not.toBeDefined();',
+    'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+    'test("valid-expect", () => { return expect(Promise.reject(2)).rejects.toBeDefined(); });',
+    'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+    'test("valid-expect", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+    'test("valid-expect", function () { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+    'test("valid-expect", function () { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+    'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined()); });',
+    'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).rejects.not.toBeDefined()); });',
+    'test("valid-expect", () => expect(Promise.resolve(2)).resolves.toBeDefined());',
+    'test("valid-expect", () => expect(Promise.reject(2)).rejects.toBeDefined());',
+    'test("valid-expect", () => expect(Promise.reject(2)).resolves.not.toBeDefined());',
+    'test("valid-expect", () => expect(Promise.reject(2)).rejects.not.toBeDefined());',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
+    'test("valid-expect", async function () { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
+    'test("valid-expect", async function () { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
+    'test("valid-expect", async () => { await Promise.resolve(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
+    'test("valid-expect", async () => { await Promise.reject(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
+    'test("valid-expect", async () => { await Promise.all([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+    'test("valid-expect", async () => { await Promise.race([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+    'test("valid-expect", async () => { await Promise.allSettled([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+    'test("valid-expect", async () => { await Promise.any([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
+    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
+    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
+    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
+    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
+    'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("valid-case")); });',
+    'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")); });',
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")).then(() => console.log("after")); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined().finally(() => console.log("cleanup")); });',
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")).catch(() => console.log("recover")); });',
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup 1")).finally(() => console.log("cleanup 2")); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("recover")).finally(() => console.log("cleanup")); });',
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+    ` test("valid-expect", () => {
            return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
              return expect(Promise.resolve(2)).resolves.toBe(1);
            });
          });
        `,
-		` test("valid-expect", () => {
+    ` test("valid-expect", () => {
            return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
              await expect(Promise.resolve(2)).resolves.toBe(1);
            });
          });
     `,
-		` test("valid-expect", () => {
+    ` test("valid-expect", () => {
            return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => expect(Promise.resolve(2)).resolves.toBe(1));
          });
        `,
-		` expect.extend({
+    ` expect.extend({
            toResolve(obj) {
              return this.isNot
                ? expect(obj).toBe(true)
@@ -73,7 +73,7 @@ ruleTester.run(rule.name, rule, {
            }
          });
        `,
-		` expect.extend({
+    ` expect.extend({
           toResolve(obj) {
             return this.isNot
               ? expect(obj).resolves.not.toThrow()
@@ -81,7 +81,7 @@ ruleTester.run(rule.name, rule, {
           }
         });
       `,
-		` expect.extend({
+    ` expect.extend({
       toResolve(obj) {
      return this.isNot
        ? expect(obj).toBe(true)
@@ -91,428 +91,428 @@ ruleTester.run(rule.name, rule, {
       }
     });
      `,
-		'expect(value, "message").toBe(1);',
-		'expect(value, `message`).toBe(1);',
-		'const message = "message"; expect(value, `${message}`).toBe(1);',
-		`it('example', () => {
+    'expect(value, "message").toBe(1);',
+    'expect(value, `message`).toBe(1);',
+    'const message = "message"; expect(value, `${message}`).toBe(1);',
+    `it('example', () => {
    expect("foo bar").to.include("foo");
 });
 `,
-		`it('example', () => {
+    `it('example', () => {
    expect("hey").to.have.property("foo", "bar")
 });
 `,
-		{
-			code: 'expect(1).toBe(2);',
-			options: [{ maxArgs: 2 }],
-		},
-		{
-			code: 'expect(1, "1 !== 2").toBe(2);',
-			options: [{ maxArgs: 2 }],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(2).not.toBe(2); });',
-			options: [{ asyncMatchers: ['toRejectWith'] }],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
-			options: [{ asyncMatchers: ['toResolveWith'] }],
-		},
-		{
-			code: 'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
-			options: [{ asyncMatchers: ['toResolveWith'] }],
-		},
-		{
-			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).toResolve(); });',
-			options: [{ asyncMatchers: ['toResolveWith'] }],
-		},
-		{
-			code: `expectTypeOf().returns.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().branded.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().asserts.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().constructorParameters.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().parameters.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().thisParameter.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().guards.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().instance.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-		{
-			code: `expectTypeOf().items.toMatchTypeOf();`,
-			settings: {
-				vitest: {
-					typecheck: true,
-				},
-			},
-		},
-	],
-	invalid: [
-		{
-			code: 'expect().toBe(2);',
-			options: [{ minArgs: undefined, maxArgs: undefined }],
-			errors: [
-				{
-					messageId: 'notEnoughArgs',
-					data: {
-						s: '',
-						amount: 1,
-					},
-				},
-			],
-		},
-		{
-			code: 'expect().toBe(true);',
-			errors: [
-				{
-					endColumn: 8,
-					column: 7,
-					messageId: 'notEnoughArgs',
-					data: {
-						s: '',
-						amount: 1,
-					},
-				},
-			],
-		},
-		{
-			code: 'expect().toEqual("something");',
-			errors: [
-				{
-					endColumn: 8,
-					column: 7,
-					messageId: 'notEnoughArgs',
-					data: {
-						s: '',
-						amount: 1,
-					},
-				},
-			],
-		},
-		{
-			code: 'expect("something", "else", "entirely").toEqual("something");',
-			options: [{ maxArgs: 2 }],
-			errors: [
-				{
-					endColumn: 40,
-					column: 29,
-					messageId: 'tooManyArgs',
-					data: {
-						s: 's',
-						amount: 2,
-					},
-				},
-			],
-		},
-		{
-			code: 'expect("something", "else", "entirely").toEqual("something");',
-			options: [{ maxArgs: 2, minArgs: 2 }],
-			errors: [
-				{
-					endColumn: 40,
-					column: 29,
-					messageId: 'tooManyArgs',
-					data: {
-						s: 's',
-						amount: 2,
-					},
-				},
-			],
-		},
-		{
-			code: 'expect("something", "else", "entirely").toEqual("something");',
-			options: [{ maxArgs: 2, minArgs: 1 }],
-			errors: [
-				{
-					endColumn: 40,
-					column: 29,
-					messageId: 'tooManyArgs',
-					data: {
-						s: 's',
-						amount: 2,
-					},
-				},
-			],
-		},
-		{
-			code: 'expect("something").toEqual("something");',
-			options: [{ minArgs: 2 }],
-			errors: [
-				{
-					endColumn: 8,
-					column: 7,
-					messageId: 'notEnoughArgs',
-					data: {
-						s: 's',
-						amount: 2,
-					},
-				},
-			],
-		},
-		{
-			code: 'expect("something", "else").toEqual("something");',
-			options: [{ maxArgs: 1, minArgs: 3 }],
-			errors: [
-				{
-					endColumn: 8,
-					column: 7,
-					messageId: 'notEnoughArgs',
-					data: {
-						s: 's',
-						amount: 3,
-					},
-				},
-			],
-		},
-		// expect() 2nd argument to be a string literal
-		{
-			code: 'expect("something", true).toEqual("something");',
-			errors: [
-				{
-					endColumn: 26,
-					column: 21,
-					messageId: 'tooManyArgs',
-				},
-			],
-		},
-		{
-			code: 'expect("something", 12).toEqual("something");',
-			errors: [
-				{
-					endColumn: 24,
-					column: 21,
-					messageId: 'tooManyArgs',
-				},
-			],
-		},
-		{
-			code: 'expect("something", {}).toEqual("something");',
-			errors: [
-				{
-					endColumn: 24,
-					column: 21,
-					messageId: 'tooManyArgs',
-				},
-			],
-		},
-		{
-			code: 'expect("something", []).toEqual("something");',
-			errors: [
-				{
-					endColumn: 24,
-					column: 21,
-					messageId: 'tooManyArgs',
-				},
-			],
-		},
-		// expect(value, "string literal") is valid, but expect(value, variable) is not
-		// because the AST does not have type information for variables
-		{
-			code: `const message = "message";
+    {
+      code: 'expect(1).toBe(2);',
+      options: [{ maxArgs: 2 }],
+    },
+    {
+      code: 'expect(1, "1 !== 2").toBe(2);',
+      options: [{ maxArgs: 2 }],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(2).not.toBe(2); });',
+      options: [{ asyncMatchers: ['toRejectWith'] }],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
+      options: [{ asyncMatchers: ['toResolveWith'] }],
+    },
+    {
+      code: 'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
+      options: [{ asyncMatchers: ['toResolveWith'] }],
+    },
+    {
+      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).toResolve(); });',
+      options: [{ asyncMatchers: ['toResolveWith'] }],
+    },
+    {
+      code: `expectTypeOf().returns.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().branded.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().asserts.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().constructorParameters.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().parameters.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().thisParameter.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().guards.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().instance.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf().items.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+  ],
+  invalid: [
+    {
+      code: 'expect().toBe(2);',
+      options: [{ minArgs: undefined, maxArgs: undefined }],
+      errors: [
+        {
+          messageId: 'notEnoughArgs',
+          data: {
+            s: '',
+            amount: 1,
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect().toBe(true);',
+      errors: [
+        {
+          endColumn: 8,
+          column: 7,
+          messageId: 'notEnoughArgs',
+          data: {
+            s: '',
+            amount: 1,
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect().toEqual("something");',
+      errors: [
+        {
+          endColumn: 8,
+          column: 7,
+          messageId: 'notEnoughArgs',
+          data: {
+            s: '',
+            amount: 1,
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect("something", "else", "entirely").toEqual("something");',
+      options: [{ maxArgs: 2 }],
+      errors: [
+        {
+          endColumn: 40,
+          column: 29,
+          messageId: 'tooManyArgs',
+          data: {
+            s: 's',
+            amount: 2,
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect("something", "else", "entirely").toEqual("something");',
+      options: [{ maxArgs: 2, minArgs: 2 }],
+      errors: [
+        {
+          endColumn: 40,
+          column: 29,
+          messageId: 'tooManyArgs',
+          data: {
+            s: 's',
+            amount: 2,
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect("something", "else", "entirely").toEqual("something");',
+      options: [{ maxArgs: 2, minArgs: 1 }],
+      errors: [
+        {
+          endColumn: 40,
+          column: 29,
+          messageId: 'tooManyArgs',
+          data: {
+            s: 's',
+            amount: 2,
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect("something").toEqual("something");',
+      options: [{ minArgs: 2 }],
+      errors: [
+        {
+          endColumn: 8,
+          column: 7,
+          messageId: 'notEnoughArgs',
+          data: {
+            s: 's',
+            amount: 2,
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect("something", "else").toEqual("something");',
+      options: [{ maxArgs: 1, minArgs: 3 }],
+      errors: [
+        {
+          endColumn: 8,
+          column: 7,
+          messageId: 'notEnoughArgs',
+          data: {
+            s: 's',
+            amount: 3,
+          },
+        },
+      ],
+    },
+    // expect() 2nd argument to be a string literal
+    {
+      code: 'expect("something", true).toEqual("something");',
+      errors: [
+        {
+          endColumn: 26,
+          column: 21,
+          messageId: 'tooManyArgs',
+        },
+      ],
+    },
+    {
+      code: 'expect("something", 12).toEqual("something");',
+      errors: [
+        {
+          endColumn: 24,
+          column: 21,
+          messageId: 'tooManyArgs',
+        },
+      ],
+    },
+    {
+      code: 'expect("something", {}).toEqual("something");',
+      errors: [
+        {
+          endColumn: 24,
+          column: 21,
+          messageId: 'tooManyArgs',
+        },
+      ],
+    },
+    {
+      code: 'expect("something", []).toEqual("something");',
+      errors: [
+        {
+          endColumn: 24,
+          column: 21,
+          messageId: 'tooManyArgs',
+        },
+      ],
+    },
+    // expect(value, "string literal") is valid, but expect(value, variable) is not
+    // because the AST does not have type information for variables
+    {
+      code: `const message = "message";
       expect(1, message).toBe(2);`,
-			errors: [
-				{
-					endColumn: 25,
-					column: 17,
-					messageId: 'tooManyArgs',
-				},
-			],
-		},
-		{
-			code: 'expect("something");',
-			errors: [{ endColumn: 20, column: 1, messageId: 'matcherNotFound' }],
-		},
-		{
-			code: 'expect();',
-			errors: [{ endColumn: 9, column: 1, messageId: 'matcherNotFound' }],
-		},
-		{
-			code: 'expect(true).toBeDefined;',
-			errors: [
-				{
-					endColumn: 25,
-					column: 14,
-					messageId: 'matcherNotCalled',
-				},
-			],
-		},
-		{
-			code: 'expect(true).not.toBeDefined;',
-			errors: [
-				{
-					endColumn: 29,
-					column: 18,
-					messageId: 'matcherNotCalled',
-				},
-			],
-		},
-		{
-			code: 'expect(true).nope.toBeDefined;',
-			errors: [
-				{
-					endColumn: 30,
-					column: 19,
-					messageId: 'matcherNotCalled',
-				},
-			],
-		},
-		{
-			code: 'expect(true).nope.toBeDefined();',
-			errors: [
-				{
-					endColumn: 32,
-					column: 1,
-					messageId: 'modifierUnknown',
-				},
-			],
-		},
-		{
-			code: 'expect(true).not.resolves.toBeDefined();',
-			errors: [
-				{
-					endColumn: 40,
-					column: 1,
-					messageId: 'modifierUnknown',
-				},
-			],
-		},
-		{
-			code: 'expect(true).not.not.toBeDefined();',
-			errors: [
-				{
-					endColumn: 35,
-					column: 1,
-					messageId: 'modifierUnknown',
-				},
-			],
-		},
-		{
-			code: 'expect(true).resolves.not.exactly.toBeDefined();',
-			errors: [
-				{
-					endColumn: 48,
-					column: 1,
-					messageId: 'modifierUnknown',
-				},
-			],
-		},
-		{
-			code: 'expect(true).resolves;',
-			errors: [
-				{
-					endColumn: 22,
-					column: 14,
-					messageId: 'matcherNotFound',
-				},
-			],
-		},
-		{
-			code: 'expect(true).rejects;',
-			errors: [
-				{
-					endColumn: 21,
-					column: 14,
-					messageId: 'matcherNotFound',
-				},
-			],
-		},
-		{
-			code: 'expect(true).not;',
-			errors: [
-				{
-					endColumn: 17,
-					column: 14,
-					messageId: 'matcherNotFound',
-				},
-			],
-		},
-		{
-			code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
-			errors: [
-				{
-					column: 1,
-					endColumn: 50,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'expect(Promise.resolve(2)).rejects.toBeDefined();',
-			errors: [
-				{
-					column: 1,
-					endColumn: 49,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
-			options: [{ alwaysAwait: true }],
-			errors: [
-				{
-					column: 1,
-					endColumn: 50,
-					messageId: 'asyncMustBeAwaited',
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          endColumn: 25,
+          column: 17,
+          messageId: 'tooManyArgs',
+        },
+      ],
+    },
+    {
+      code: 'expect("something");',
+      errors: [{ endColumn: 20, column: 1, messageId: 'matcherNotFound' }],
+    },
+    {
+      code: 'expect();',
+      errors: [{ endColumn: 9, column: 1, messageId: 'matcherNotFound' }],
+    },
+    {
+      code: 'expect(true).toBeDefined;',
+      errors: [
+        {
+          endColumn: 25,
+          column: 14,
+          messageId: 'matcherNotCalled',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not.toBeDefined;',
+      errors: [
+        {
+          endColumn: 29,
+          column: 18,
+          messageId: 'matcherNotCalled',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).nope.toBeDefined;',
+      errors: [
+        {
+          endColumn: 30,
+          column: 19,
+          messageId: 'matcherNotCalled',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).nope.toBeDefined();',
+      errors: [
+        {
+          endColumn: 32,
+          column: 1,
+          messageId: 'modifierUnknown',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not.resolves.toBeDefined();',
+      errors: [
+        {
+          endColumn: 40,
+          column: 1,
+          messageId: 'modifierUnknown',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not.not.toBeDefined();',
+      errors: [
+        {
+          endColumn: 35,
+          column: 1,
+          messageId: 'modifierUnknown',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).resolves.not.exactly.toBeDefined();',
+      errors: [
+        {
+          endColumn: 48,
+          column: 1,
+          messageId: 'modifierUnknown',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).resolves;',
+      errors: [
+        {
+          endColumn: 22,
+          column: 14,
+          messageId: 'matcherNotFound',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).rejects;',
+      errors: [
+        {
+          endColumn: 21,
+          column: 14,
+          messageId: 'matcherNotFound',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not;',
+      errors: [
+        {
+          endColumn: 17,
+          column: 14,
+          messageId: 'matcherNotFound',
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
+      errors: [
+        {
+          column: 1,
+          endColumn: 50,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve(2)).rejects.toBeDefined();',
+      errors: [
+        {
+          column: 1,
+          endColumn: 49,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
+      options: [{ alwaysAwait: true }],
+      errors: [
+        {
+          column: 1,
+          endColumn: 50,
+          messageId: 'asyncMustBeAwaited',
+        },
+      ],
+    },
+    {
+      code: `
      expect.extend({
        toResolve(obj) {
       this.isNot
@@ -521,7 +521,7 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-			output: `
+      output: `
      expect.extend({
        async toResolve(obj) {
       this.isNot
@@ -530,16 +530,16 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-			errors: [
-				{
-					column: 11,
-					endColumn: 45,
-					messageId: 'asyncMustBeAwaited',
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          column: 11,
+          endColumn: 45,
+          messageId: 'asyncMustBeAwaited',
+        },
+      ],
+    },
+    {
+      code: `
      expect.extend({
        toResolve(obj) {
       this.isNot
@@ -548,7 +548,7 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-			output: `
+      output: `
      expect.extend({
        async toResolve(obj) {
       this.isNot
@@ -557,320 +557,320 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-			errors: [
-				{
-					column: 11,
-					endColumn: 45,
-					messageId: 'asyncMustBeAwaited',
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-			errors: [
-				{
-					column: 30,
-					endColumn: 79,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 30,
-					line: 1,
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
-			options: [{ asyncMatchers: undefined }],
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 30,
-					line: 1,
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toReject(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).toReject(); });',
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 30,
-					line: 1,
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).not.toReject(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).not.toReject(); });',
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 30,
-					line: 1,
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-			errors: [
-				{
-					column: 30,
-					endColumn: 83,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.toBeDefined(); });',
-			errors: [
-				{
-					column: 30,
-					endColumn: 78,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-			errors: [
-				{
-					column: 30,
-					endColumn: 82,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-			errors: [
-				{
-					column: 36,
-					endColumn: 85,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-			errors: [
-				{
-					column: 36,
-					endColumn: 89,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.reject(2)).toRejectWith(2); });',
-			options: [{ asyncMatchers: ['toRejectWith'] }],
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 30,
-				},
-			],
-		},
-		{
-			code: 'test("valid-expect", () => { expect(Promise.reject(2)).rejects.toBe(2); });',
-			output:
-				'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.toBe(2); });',
-			options: [{ asyncMatchers: ['toRejectWith'] }],
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 30,
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          column: 11,
+          endColumn: 45,
+          messageId: 'asyncMustBeAwaited',
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+      errors: [
+        {
+          column: 30,
+          endColumn: 79,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 30,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
+      options: [{ asyncMatchers: undefined }],
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 30,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toReject(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).toReject(); });',
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 30,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).not.toReject(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).not.toReject(); });',
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 30,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+      errors: [
+        {
+          column: 30,
+          endColumn: 83,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.toBeDefined(); });',
+      errors: [
+        {
+          column: 30,
+          endColumn: 78,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+      errors: [
+        {
+          column: 30,
+          endColumn: 82,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+      errors: [
+        {
+          column: 36,
+          endColumn: 85,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+      errors: [
+        {
+          column: 36,
+          endColumn: 89,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.reject(2)).toRejectWith(2); });',
+      options: [{ asyncMatchers: ['toRejectWith'] }],
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 30,
+        },
+      ],
+    },
+    {
+      code: 'test("valid-expect", () => { expect(Promise.reject(2)).rejects.toBe(2); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.toBe(2); });',
+      options: [{ asyncMatchers: ['toRejectWith'] }],
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 30,
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", async () => {
       expect(Promise.resolve(2)).resolves.not.toBeDefined();
       expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			output: `
+      output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       await expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			errors: [
-				{
-					line: 3,
-					column: 7,
-					endColumn: 60,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-				{
-					line: 4,
-					column: 7,
-					endColumn: 55,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 3,
+          column: 7,
+          endColumn: 60,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+        {
+          line: 4,
+          column: 7,
+          endColumn: 55,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			output: `
+      output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       await expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			errors: [
-				{
-					line: 4,
-					column: 7,
-					endColumn: 55,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 4,
+          column: 7,
+          endColumn: 55,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", async () => {
       expect(Promise.resolve(2)).resolves.not.toBeDefined();
       return expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			output: `
+      output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       await expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			options: [{ alwaysAwait: true }],
-			errors: [
-				{
-					line: 3,
-					column: 7,
-					endColumn: 60,
-					messageId: 'asyncMustBeAwaited',
-				},
-				{
-					line: 4,
-					column: 14,
-					endColumn: 62,
-					messageId: 'asyncMustBeAwaited',
-				},
-			],
-		},
-		{
-			code: `
+      options: [{ alwaysAwait: true }],
+      errors: [
+        {
+          line: 3,
+          column: 7,
+          endColumn: 60,
+          messageId: 'asyncMustBeAwaited',
+        },
+        {
+          line: 4,
+          column: 14,
+          endColumn: 62,
+          messageId: 'asyncMustBeAwaited',
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", async () => {
       expect(Promise.resolve(2)).resolves.not.toBeDefined();
       return expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			output: `
+      output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       return expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-			errors: [
-				{
-					line: 3,
-					column: 7,
-					endColumn: 60,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 3,
+          column: 7,
+          endColumn: 60,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", () => {
       Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
        });
      `,
-			output: `
+      output: `
        test("valid-expect", async () => {
       await Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
        });
      `,
-			errors: [
-				{
-					line: 3,
-					column: 7,
-					endColumn: 71,
-					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 3,
+          column: 7,
+          endColumn: 71,
+          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
      test("valid-expect", () => {
        Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
      });
       `,
-			output: `
+      output: `
      test("valid-expect", async () => {
        await Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
      });
       `,
-			options: [{ alwaysAwait: true }],
-			errors: [
-				{
-					line: 3,
-					column: 8,
-					endColumn: 78,
-					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-				},
-			],
-		},
-		{
-			code: `
+      options: [{ alwaysAwait: true }],
+      errors: [
+        {
+          line: 3,
+          column: 8,
+          endColumn: 78,
+          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+        },
+      ],
+    },
+    {
+      code: `
      test("valid-expect", () => {
       Promise.all([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -878,7 +878,7 @@ ruleTester.run(rule.name, rule, {
       ]);
        });
        `,
-			output: `
+      output: `
      test("valid-expect", async () => {
       await Promise.all([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -886,45 +886,45 @@ ruleTester.run(rule.name, rule, {
       ]);
        });
        `,
-			errors: [
-				{
-					line: 3,
-					column: 7,
-					endLine: 6,
-					endColumn: 9,
-					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 3,
+          column: 7,
+          endLine: 6,
+          endColumn: 9,
+          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
      test("valid-expect", () => {
       Promise.x([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
         expect(Promise.resolve(3)).resolves.not.toBeDefined(),
       ]);
        });`,
-			output: `
+      output: `
      test("valid-expect", async () => {
       await Promise.x([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
         expect(Promise.resolve(3)).resolves.not.toBeDefined(),
       ]);
        });`,
-			errors: [
-				{
-					line: 3,
-					column: 7,
-					endLine: 6,
-					endColumn: 9,
-					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 3,
+          column: 7,
+          endLine: 6,
+          endColumn: 9,
+          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", () => {
       const assertions = [
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -932,7 +932,7 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-			output: `
+      output: `
        test("valid-expect", async () => {
       const assertions = [
         await expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -940,27 +940,27 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-			errors: [
-				{
-					line: 4,
-					column: 9,
-					endLine: 4,
-					endColumn: 62,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-				{
-					line: 5,
-					column: 9,
-					endLine: 5,
-					endColumn: 62,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 4,
+          column: 9,
+          endLine: 4,
+          endColumn: 62,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+        {
+          line: 5,
+          column: 9,
+          endLine: 5,
+          endColumn: 62,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
      test("valid-expect", () => {
        const assertions = [
       expect(Promise.resolve(2)).toResolve(),
@@ -968,7 +968,7 @@ ruleTester.run(rule.name, rule, {
        ]
      });
       `,
-			output: `
+      output: `
      test("valid-expect", async () => {
        const assertions = [
       await expect(Promise.resolve(2)).toResolve(),
@@ -976,23 +976,23 @@ ruleTester.run(rule.name, rule, {
        ]
      });
       `,
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 7,
-					line: 4,
-				},
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 7,
-					line: 5,
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 7,
+          line: 4,
+        },
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 7,
+          line: 5,
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", () => {
       const assertions = [
         expect(Promise.resolve(2)).not.toResolve(),
@@ -1000,7 +1000,7 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-			output: `
+      output: `
        test("valid-expect", async () => {
       const assertions = [
         await expect(Promise.resolve(2)).not.toResolve(),
@@ -1008,59 +1008,59 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-			errors: [
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 9,
-					line: 4,
-				},
-				{
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-					column: 9,
-					line: 5,
-				},
-			],
-		},
-		{
-			code: 'expect(Promise.resolve(2)).resolves.toBe;',
-			errors: [
-				{
-					column: 37,
-					endColumn: 41,
-					messageId: 'matcherNotCalled',
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 9,
+          line: 4,
+        },
+        {
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+          column: 9,
+          line: 5,
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve(2)).resolves.toBe;',
+      errors: [
+        {
+          column: 37,
+          endColumn: 41,
+          messageId: 'matcherNotCalled',
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
         expect(Promise.resolve(2)).resolves.toBe(1);
       });
        });
      `,
-			output: `
+      output: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
         await expect(Promise.resolve(2)).resolves.toBe(1);
       });
        });
      `,
-			errors: [
-				{
-					line: 4,
-					column: 9,
-					endLine: 4,
-					endColumn: 52,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 4,
+          column: 9,
+          endLine: 4,
+          endColumn: 52,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
         await expect(Promise.resolve(2)).resolves.toBe(1);
@@ -1068,7 +1068,7 @@ ruleTester.run(rule.name, rule, {
       });
        });
      `,
-			output: `
+      output: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
         await expect(Promise.resolve(2)).resolves.toBe(1);
@@ -1076,43 +1076,43 @@ ruleTester.run(rule.name, rule, {
       });
        });
      `,
-			errors: [
-				{
-					line: 5,
-					column: 9,
-					endLine: 5,
-					endColumn: 52,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-		{
-			code: `
+      errors: [
+        {
+          line: 5,
+          column: 9,
+          endLine: 5,
+          endColumn: 52,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(1));
        });
      `,
-			errors: [{ endColumn: 39, column: 13, messageId: 'matcherNotFound' }],
-		},
-		{
-			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
-			output:
-				'test("valid-expect", async () => { await await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
-			errors: [
-				{
-					column: 36,
-					endColumn: 127,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-				{
-					column: 36,
-					endColumn: 127,
-					messageId: 'asyncMustBeAwaited',
-					data: { orReturned: ' or returned' },
-				},
-			],
-		},
-	],
+      errors: [{ endColumn: 39, column: 13, messageId: 'matcherNotFound' }],
+    },
+    {
+      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+      output:
+        'test("valid-expect", async () => { await await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+      errors: [
+        {
+          column: 36,
+          endColumn: 127,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+        {
+          column: 36,
+          endColumn: 127,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+  ],
 })

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -41,6 +41,23 @@ ruleTester.run(rule.name, rule, {
     'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
     'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
     'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
+    // .finally() in async assertion chains (issue #904)
+    // P1: .finally() directly after an async assertion (return-form)
+    'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("valid-case")); });',
+    // P2: .then() then .finally() (return-form)
+    'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")); });',
+    // E1: .then(), .finally(), then .then() again (await-form)
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")).then(() => console.log("after")); });',
+    // E2: rejects assertion + .finally() (await-form)
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined().finally(() => console.log("cleanup")); });',
+    // E4: .finally() before .catch() (await-form)
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")).catch(() => console.log("recover")); });',
+    // E5: multiple .finally() in a row (await-form)
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup 1")).finally(() => console.log("cleanup 2")); });',
+    // E6: .catch() then .finally() (await-form)
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("recover")).finally(() => console.log("cleanup")); });',
+    // E7: .finally() directly after async assertion (await-form)
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
     ` test("valid-expect", () => {
            return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
              return expect(Promise.resolve(2)).resolves.toBe(1);
@@ -1086,6 +1103,30 @@ ruleTester.run(rule.name, rule, {
        });
      `,
       errors: [{ endColumn: 39, column: 13, messageId: 'matcherNotFound' }],
+    },
+    // N1 (issue #904): unawaited async assertion chained with .finally() is still flagged
+    // after the fix. The chain walker now treats .finally() as part of the chain (same
+    // as .then()/.catch()), so the reported range covers the whole chain instead of
+    // stopping before .finally(). The pair of reports/inserts mirrors the long-standing
+    // behavior on .then()/.catch() chains and is independent of this fix.
+    {
+      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+      output:
+        'test("valid-expect", async () => { await await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+      errors: [
+        {
+          column: 36,
+          endColumn: 127,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+        {
+          column: 36,
+          endColumn: 127,
+          messageId: 'asyncMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
     },
   ],
 })

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -2,79 +2,70 @@ import rule from '../src/rules/valid-expect'
 import { ruleTester } from './ruleTester'
 
 ruleTester.run(rule.name, rule, {
-  valid: [
-    'expect.hasAssertions',
-    'expect.hasAssertions()',
-    'expect("something").toEqual("else");',
-    'expect(true).toBeDefined();',
-    'expect([1, 2, 3]).toEqual([1, 2, 3]);',
-    'expect(undefined).not.toBeDefined();',
-    'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-    'test("valid-expect", () => { return expect(Promise.reject(2)).rejects.toBeDefined(); });',
-    'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-    'test("valid-expect", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-    'test("valid-expect", function () { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-    'test("valid-expect", function () { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-    'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined()); });',
-    'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).rejects.not.toBeDefined()); });',
-    'test("valid-expect", () => expect(Promise.resolve(2)).resolves.toBeDefined());',
-    'test("valid-expect", () => expect(Promise.reject(2)).rejects.toBeDefined());',
-    'test("valid-expect", () => expect(Promise.reject(2)).resolves.not.toBeDefined());',
-    'test("valid-expect", () => expect(Promise.reject(2)).rejects.not.toBeDefined());',
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
-    'test("valid-expect", async function () { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
-    'test("valid-expect", async function () { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
-    'test("valid-expect", async () => { await Promise.resolve(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
-    'test("valid-expect", async () => { await Promise.reject(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
-    'test("valid-expect", async () => { await Promise.all([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-    'test("valid-expect", async () => { await Promise.race([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-    'test("valid-expect", async () => { await Promise.allSettled([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-    'test("valid-expect", async () => { await Promise.any([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
-    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
-    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
-    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
-    'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
-    // .finally() in async assertion chains (issue #904)
-    // P1: .finally() directly after an async assertion (return-form)
-    'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("valid-case")); });',
-    // P2: .then() then .finally() (return-form)
-    'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")); });',
-    // E1: .then(), .finally(), then .then() again (await-form)
-    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")).then(() => console.log("after")); });',
-    // E2: rejects assertion + .finally() (await-form)
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined().finally(() => console.log("cleanup")); });',
-    // E4: .finally() before .catch() (await-form)
-    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")).catch(() => console.log("recover")); });',
-    // E5: multiple .finally() in a row (await-form)
-    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup 1")).finally(() => console.log("cleanup 2")); });',
-    // E6: .catch() then .finally() (await-form)
-    'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("recover")).finally(() => console.log("cleanup")); });',
-    // E7: .finally() directly after async assertion (await-form)
-    'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
-    ` test("valid-expect", () => {
+	valid: [
+		'expect.hasAssertions',
+		'expect.hasAssertions()',
+		'expect("something").toEqual("else");',
+		'expect(true).toBeDefined();',
+		'expect([1, 2, 3]).toEqual([1, 2, 3]);',
+		'expect(undefined).not.toBeDefined();',
+		'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+		'test("valid-expect", () => { return expect(Promise.reject(2)).rejects.toBeDefined(); });',
+		'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+		'test("valid-expect", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+		'test("valid-expect", function () { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+		'test("valid-expect", function () { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+		'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined()); });',
+		'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).rejects.not.toBeDefined()); });',
+		'test("valid-expect", () => expect(Promise.resolve(2)).resolves.toBeDefined());',
+		'test("valid-expect", () => expect(Promise.reject(2)).rejects.toBeDefined());',
+		'test("valid-expect", () => expect(Promise.reject(2)).resolves.not.toBeDefined());',
+		'test("valid-expect", () => expect(Promise.reject(2)).rejects.not.toBeDefined());',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
+		'test("valid-expect", async function () { await expect(Promise.reject(2)).resolves.not.toBeDefined(); });',
+		'test("valid-expect", async function () { await expect(Promise.reject(2)).rejects.not.toBeDefined(); });',
+		'test("valid-expect", async () => { await Promise.resolve(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
+		'test("valid-expect", async () => { await Promise.reject(expect(Promise.reject(2)).rejects.not.toBeDefined()); });',
+		'test("valid-expect", async () => { await Promise.all([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+		'test("valid-expect", async () => { await Promise.race([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+		'test("valid-expect", async () => { await Promise.allSettled([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+		'test("valid-expect", async () => { await Promise.any([expect(Promise.reject(2)).rejects.not.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
+		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
+		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
+		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
+		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
+		'test("valid-expect", async () => { return expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).then(() => console.log("another valid case")); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
+		'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("valid-case")); });',
+		'test("valid-expect", async () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")); });',
+		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).finally(() => console.log("cleanup")).then(() => console.log("after")); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.not.toBeDefined().finally(() => console.log("cleanup")); });',
+		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")).catch(() => console.log("recover")); });',
+		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup 1")).finally(() => console.log("cleanup 2")); });',
+		'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("recover")).finally(() => console.log("cleanup")); });',
+		'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+		` test("valid-expect", () => {
            return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
              return expect(Promise.resolve(2)).resolves.toBe(1);
            });
          });
        `,
-    ` test("valid-expect", () => {
+		` test("valid-expect", () => {
            return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
              await expect(Promise.resolve(2)).resolves.toBe(1);
            });
          });
     `,
-    ` test("valid-expect", () => {
+		` test("valid-expect", () => {
            return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => expect(Promise.resolve(2)).resolves.toBe(1));
          });
        `,
-    ` expect.extend({
+		` expect.extend({
            toResolve(obj) {
              return this.isNot
                ? expect(obj).toBe(true)
@@ -82,7 +73,7 @@ ruleTester.run(rule.name, rule, {
            }
          });
        `,
-    ` expect.extend({
+		` expect.extend({
           toResolve(obj) {
             return this.isNot
               ? expect(obj).resolves.not.toThrow()
@@ -90,7 +81,7 @@ ruleTester.run(rule.name, rule, {
           }
         });
       `,
-    ` expect.extend({
+		` expect.extend({
       toResolve(obj) {
      return this.isNot
        ? expect(obj).toBe(true)
@@ -100,428 +91,428 @@ ruleTester.run(rule.name, rule, {
       }
     });
      `,
-    'expect(value, "message").toBe(1);',
-    'expect(value, `message`).toBe(1);',
-    'const message = "message"; expect(value, `${message}`).toBe(1);',
-    `it('example', () => {
+		'expect(value, "message").toBe(1);',
+		'expect(value, `message`).toBe(1);',
+		'const message = "message"; expect(value, `${message}`).toBe(1);',
+		`it('example', () => {
    expect("foo bar").to.include("foo");
 });
 `,
-    `it('example', () => {
+		`it('example', () => {
    expect("hey").to.have.property("foo", "bar")
 });
 `,
-    {
-      code: 'expect(1).toBe(2);',
-      options: [{ maxArgs: 2 }],
-    },
-    {
-      code: 'expect(1, "1 !== 2").toBe(2);',
-      options: [{ maxArgs: 2 }],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(2).not.toBe(2); });',
-      options: [{ asyncMatchers: ['toRejectWith'] }],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
-      options: [{ asyncMatchers: ['toResolveWith'] }],
-    },
-    {
-      code: 'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
-      options: [{ asyncMatchers: ['toResolveWith'] }],
-    },
-    {
-      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).toResolve(); });',
-      options: [{ asyncMatchers: ['toResolveWith'] }],
-    },
-    {
-      code: `expectTypeOf().returns.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().branded.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().asserts.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().constructorParameters.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().parameters.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().thisParameter.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().guards.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().instance.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-    {
-      code: `expectTypeOf().items.toMatchTypeOf();`,
-      settings: {
-        vitest: {
-          typecheck: true,
-        },
-      },
-    },
-  ],
-  invalid: [
-    {
-      code: 'expect().toBe(2);',
-      options: [{ minArgs: undefined, maxArgs: undefined }],
-      errors: [
-        {
-          messageId: 'notEnoughArgs',
-          data: {
-            s: '',
-            amount: 1,
-          },
-        },
-      ],
-    },
-    {
-      code: 'expect().toBe(true);',
-      errors: [
-        {
-          endColumn: 8,
-          column: 7,
-          messageId: 'notEnoughArgs',
-          data: {
-            s: '',
-            amount: 1,
-          },
-        },
-      ],
-    },
-    {
-      code: 'expect().toEqual("something");',
-      errors: [
-        {
-          endColumn: 8,
-          column: 7,
-          messageId: 'notEnoughArgs',
-          data: {
-            s: '',
-            amount: 1,
-          },
-        },
-      ],
-    },
-    {
-      code: 'expect("something", "else", "entirely").toEqual("something");',
-      options: [{ maxArgs: 2 }],
-      errors: [
-        {
-          endColumn: 40,
-          column: 29,
-          messageId: 'tooManyArgs',
-          data: {
-            s: 's',
-            amount: 2,
-          },
-        },
-      ],
-    },
-    {
-      code: 'expect("something", "else", "entirely").toEqual("something");',
-      options: [{ maxArgs: 2, minArgs: 2 }],
-      errors: [
-        {
-          endColumn: 40,
-          column: 29,
-          messageId: 'tooManyArgs',
-          data: {
-            s: 's',
-            amount: 2,
-          },
-        },
-      ],
-    },
-    {
-      code: 'expect("something", "else", "entirely").toEqual("something");',
-      options: [{ maxArgs: 2, minArgs: 1 }],
-      errors: [
-        {
-          endColumn: 40,
-          column: 29,
-          messageId: 'tooManyArgs',
-          data: {
-            s: 's',
-            amount: 2,
-          },
-        },
-      ],
-    },
-    {
-      code: 'expect("something").toEqual("something");',
-      options: [{ minArgs: 2 }],
-      errors: [
-        {
-          endColumn: 8,
-          column: 7,
-          messageId: 'notEnoughArgs',
-          data: {
-            s: 's',
-            amount: 2,
-          },
-        },
-      ],
-    },
-    {
-      code: 'expect("something", "else").toEqual("something");',
-      options: [{ maxArgs: 1, minArgs: 3 }],
-      errors: [
-        {
-          endColumn: 8,
-          column: 7,
-          messageId: 'notEnoughArgs',
-          data: {
-            s: 's',
-            amount: 3,
-          },
-        },
-      ],
-    },
-    // expect() 2nd argument to be a string literal
-    {
-      code: 'expect("something", true).toEqual("something");',
-      errors: [
-        {
-          endColumn: 26,
-          column: 21,
-          messageId: 'tooManyArgs',
-        },
-      ],
-    },
-    {
-      code: 'expect("something", 12).toEqual("something");',
-      errors: [
-        {
-          endColumn: 24,
-          column: 21,
-          messageId: 'tooManyArgs',
-        },
-      ],
-    },
-    {
-      code: 'expect("something", {}).toEqual("something");',
-      errors: [
-        {
-          endColumn: 24,
-          column: 21,
-          messageId: 'tooManyArgs',
-        },
-      ],
-    },
-    {
-      code: 'expect("something", []).toEqual("something");',
-      errors: [
-        {
-          endColumn: 24,
-          column: 21,
-          messageId: 'tooManyArgs',
-        },
-      ],
-    },
-    // expect(value, "string literal") is valid, but expect(value, variable) is not
-    // because the AST does not have type information for variables
-    {
-      code: `const message = "message";
+		{
+			code: 'expect(1).toBe(2);',
+			options: [{ maxArgs: 2 }],
+		},
+		{
+			code: 'expect(1, "1 !== 2").toBe(2);',
+			options: [{ maxArgs: 2 }],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(2).not.toBe(2); });',
+			options: [{ asyncMatchers: ['toRejectWith'] }],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
+			options: [{ asyncMatchers: ['toResolveWith'] }],
+		},
+		{
+			code: 'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
+			options: [{ asyncMatchers: ['toResolveWith'] }],
+		},
+		{
+			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).toResolve(); });',
+			options: [{ asyncMatchers: ['toResolveWith'] }],
+		},
+		{
+			code: `expectTypeOf().returns.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().branded.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().asserts.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().constructorParameters.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().parameters.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().thisParameter.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().guards.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().instance.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+		{
+			code: `expectTypeOf().items.toMatchTypeOf();`,
+			settings: {
+				vitest: {
+					typecheck: true,
+				},
+			},
+		},
+	],
+	invalid: [
+		{
+			code: 'expect().toBe(2);',
+			options: [{ minArgs: undefined, maxArgs: undefined }],
+			errors: [
+				{
+					messageId: 'notEnoughArgs',
+					data: {
+						s: '',
+						amount: 1,
+					},
+				},
+			],
+		},
+		{
+			code: 'expect().toBe(true);',
+			errors: [
+				{
+					endColumn: 8,
+					column: 7,
+					messageId: 'notEnoughArgs',
+					data: {
+						s: '',
+						amount: 1,
+					},
+				},
+			],
+		},
+		{
+			code: 'expect().toEqual("something");',
+			errors: [
+				{
+					endColumn: 8,
+					column: 7,
+					messageId: 'notEnoughArgs',
+					data: {
+						s: '',
+						amount: 1,
+					},
+				},
+			],
+		},
+		{
+			code: 'expect("something", "else", "entirely").toEqual("something");',
+			options: [{ maxArgs: 2 }],
+			errors: [
+				{
+					endColumn: 40,
+					column: 29,
+					messageId: 'tooManyArgs',
+					data: {
+						s: 's',
+						amount: 2,
+					},
+				},
+			],
+		},
+		{
+			code: 'expect("something", "else", "entirely").toEqual("something");',
+			options: [{ maxArgs: 2, minArgs: 2 }],
+			errors: [
+				{
+					endColumn: 40,
+					column: 29,
+					messageId: 'tooManyArgs',
+					data: {
+						s: 's',
+						amount: 2,
+					},
+				},
+			],
+		},
+		{
+			code: 'expect("something", "else", "entirely").toEqual("something");',
+			options: [{ maxArgs: 2, minArgs: 1 }],
+			errors: [
+				{
+					endColumn: 40,
+					column: 29,
+					messageId: 'tooManyArgs',
+					data: {
+						s: 's',
+						amount: 2,
+					},
+				},
+			],
+		},
+		{
+			code: 'expect("something").toEqual("something");',
+			options: [{ minArgs: 2 }],
+			errors: [
+				{
+					endColumn: 8,
+					column: 7,
+					messageId: 'notEnoughArgs',
+					data: {
+						s: 's',
+						amount: 2,
+					},
+				},
+			],
+		},
+		{
+			code: 'expect("something", "else").toEqual("something");',
+			options: [{ maxArgs: 1, minArgs: 3 }],
+			errors: [
+				{
+					endColumn: 8,
+					column: 7,
+					messageId: 'notEnoughArgs',
+					data: {
+						s: 's',
+						amount: 3,
+					},
+				},
+			],
+		},
+		// expect() 2nd argument to be a string literal
+		{
+			code: 'expect("something", true).toEqual("something");',
+			errors: [
+				{
+					endColumn: 26,
+					column: 21,
+					messageId: 'tooManyArgs',
+				},
+			],
+		},
+		{
+			code: 'expect("something", 12).toEqual("something");',
+			errors: [
+				{
+					endColumn: 24,
+					column: 21,
+					messageId: 'tooManyArgs',
+				},
+			],
+		},
+		{
+			code: 'expect("something", {}).toEqual("something");',
+			errors: [
+				{
+					endColumn: 24,
+					column: 21,
+					messageId: 'tooManyArgs',
+				},
+			],
+		},
+		{
+			code: 'expect("something", []).toEqual("something");',
+			errors: [
+				{
+					endColumn: 24,
+					column: 21,
+					messageId: 'tooManyArgs',
+				},
+			],
+		},
+		// expect(value, "string literal") is valid, but expect(value, variable) is not
+		// because the AST does not have type information for variables
+		{
+			code: `const message = "message";
       expect(1, message).toBe(2);`,
-      errors: [
-        {
-          endColumn: 25,
-          column: 17,
-          messageId: 'tooManyArgs',
-        },
-      ],
-    },
-    {
-      code: 'expect("something");',
-      errors: [{ endColumn: 20, column: 1, messageId: 'matcherNotFound' }],
-    },
-    {
-      code: 'expect();',
-      errors: [{ endColumn: 9, column: 1, messageId: 'matcherNotFound' }],
-    },
-    {
-      code: 'expect(true).toBeDefined;',
-      errors: [
-        {
-          endColumn: 25,
-          column: 14,
-          messageId: 'matcherNotCalled',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).not.toBeDefined;',
-      errors: [
-        {
-          endColumn: 29,
-          column: 18,
-          messageId: 'matcherNotCalled',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).nope.toBeDefined;',
-      errors: [
-        {
-          endColumn: 30,
-          column: 19,
-          messageId: 'matcherNotCalled',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).nope.toBeDefined();',
-      errors: [
-        {
-          endColumn: 32,
-          column: 1,
-          messageId: 'modifierUnknown',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).not.resolves.toBeDefined();',
-      errors: [
-        {
-          endColumn: 40,
-          column: 1,
-          messageId: 'modifierUnknown',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).not.not.toBeDefined();',
-      errors: [
-        {
-          endColumn: 35,
-          column: 1,
-          messageId: 'modifierUnknown',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).resolves.not.exactly.toBeDefined();',
-      errors: [
-        {
-          endColumn: 48,
-          column: 1,
-          messageId: 'modifierUnknown',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).resolves;',
-      errors: [
-        {
-          endColumn: 22,
-          column: 14,
-          messageId: 'matcherNotFound',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).rejects;',
-      errors: [
-        {
-          endColumn: 21,
-          column: 14,
-          messageId: 'matcherNotFound',
-        },
-      ],
-    },
-    {
-      code: 'expect(true).not;',
-      errors: [
-        {
-          endColumn: 17,
-          column: 14,
-          messageId: 'matcherNotFound',
-        },
-      ],
-    },
-    {
-      code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
-      errors: [
-        {
-          column: 1,
-          endColumn: 50,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'expect(Promise.resolve(2)).rejects.toBeDefined();',
-      errors: [
-        {
-          column: 1,
-          endColumn: 49,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
-      options: [{ alwaysAwait: true }],
-      errors: [
-        {
-          column: 1,
-          endColumn: 50,
-          messageId: 'asyncMustBeAwaited',
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					endColumn: 25,
+					column: 17,
+					messageId: 'tooManyArgs',
+				},
+			],
+		},
+		{
+			code: 'expect("something");',
+			errors: [{ endColumn: 20, column: 1, messageId: 'matcherNotFound' }],
+		},
+		{
+			code: 'expect();',
+			errors: [{ endColumn: 9, column: 1, messageId: 'matcherNotFound' }],
+		},
+		{
+			code: 'expect(true).toBeDefined;',
+			errors: [
+				{
+					endColumn: 25,
+					column: 14,
+					messageId: 'matcherNotCalled',
+				},
+			],
+		},
+		{
+			code: 'expect(true).not.toBeDefined;',
+			errors: [
+				{
+					endColumn: 29,
+					column: 18,
+					messageId: 'matcherNotCalled',
+				},
+			],
+		},
+		{
+			code: 'expect(true).nope.toBeDefined;',
+			errors: [
+				{
+					endColumn: 30,
+					column: 19,
+					messageId: 'matcherNotCalled',
+				},
+			],
+		},
+		{
+			code: 'expect(true).nope.toBeDefined();',
+			errors: [
+				{
+					endColumn: 32,
+					column: 1,
+					messageId: 'modifierUnknown',
+				},
+			],
+		},
+		{
+			code: 'expect(true).not.resolves.toBeDefined();',
+			errors: [
+				{
+					endColumn: 40,
+					column: 1,
+					messageId: 'modifierUnknown',
+				},
+			],
+		},
+		{
+			code: 'expect(true).not.not.toBeDefined();',
+			errors: [
+				{
+					endColumn: 35,
+					column: 1,
+					messageId: 'modifierUnknown',
+				},
+			],
+		},
+		{
+			code: 'expect(true).resolves.not.exactly.toBeDefined();',
+			errors: [
+				{
+					endColumn: 48,
+					column: 1,
+					messageId: 'modifierUnknown',
+				},
+			],
+		},
+		{
+			code: 'expect(true).resolves;',
+			errors: [
+				{
+					endColumn: 22,
+					column: 14,
+					messageId: 'matcherNotFound',
+				},
+			],
+		},
+		{
+			code: 'expect(true).rejects;',
+			errors: [
+				{
+					endColumn: 21,
+					column: 14,
+					messageId: 'matcherNotFound',
+				},
+			],
+		},
+		{
+			code: 'expect(true).not;',
+			errors: [
+				{
+					endColumn: 17,
+					column: 14,
+					messageId: 'matcherNotFound',
+				},
+			],
+		},
+		{
+			code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
+			errors: [
+				{
+					column: 1,
+					endColumn: 50,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'expect(Promise.resolve(2)).rejects.toBeDefined();',
+			errors: [
+				{
+					column: 1,
+					endColumn: 49,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
+			options: [{ alwaysAwait: true }],
+			errors: [
+				{
+					column: 1,
+					endColumn: 50,
+					messageId: 'asyncMustBeAwaited',
+				},
+			],
+		},
+		{
+			code: `
      expect.extend({
        toResolve(obj) {
       this.isNot
@@ -530,7 +521,7 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-      output: `
+			output: `
      expect.extend({
        async toResolve(obj) {
       this.isNot
@@ -539,16 +530,16 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-      errors: [
-        {
-          column: 11,
-          endColumn: 45,
-          messageId: 'asyncMustBeAwaited',
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					column: 11,
+					endColumn: 45,
+					messageId: 'asyncMustBeAwaited',
+				},
+			],
+		},
+		{
+			code: `
      expect.extend({
        toResolve(obj) {
       this.isNot
@@ -557,7 +548,7 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-      output: `
+			output: `
      expect.extend({
        async toResolve(obj) {
       this.isNot
@@ -566,320 +557,320 @@ ruleTester.run(rule.name, rule, {
        }
      });
       `,
-      errors: [
-        {
-          column: 11,
-          endColumn: 45,
-          messageId: 'asyncMustBeAwaited',
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-      errors: [
-        {
-          column: 30,
-          endColumn: 79,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 30,
-          line: 1,
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
-      options: [{ asyncMatchers: undefined }],
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 30,
-          line: 1,
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toReject(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).toReject(); });',
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 30,
-          line: 1,
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).not.toReject(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).not.toReject(); });',
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 30,
-          line: 1,
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-      errors: [
-        {
-          column: 30,
-          endColumn: 83,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.toBeDefined(); });',
-      errors: [
-        {
-          column: 30,
-          endColumn: 78,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
-      errors: [
-        {
-          column: 30,
-          endColumn: 82,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
-      errors: [
-        {
-          column: 36,
-          endColumn: 85,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
-      errors: [
-        {
-          column: 36,
-          endColumn: 89,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.reject(2)).toRejectWith(2); });',
-      options: [{ asyncMatchers: ['toRejectWith'] }],
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 30,
-        },
-      ],
-    },
-    {
-      code: 'test("valid-expect", () => { expect(Promise.reject(2)).rejects.toBe(2); });',
-      output:
-        'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.toBe(2); });',
-      options: [{ asyncMatchers: ['toRejectWith'] }],
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 30,
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					column: 11,
+					endColumn: 45,
+					messageId: 'asyncMustBeAwaited',
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+			errors: [
+				{
+					column: 30,
+					endColumn: 79,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 30,
+					line: 1,
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toResolve(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).toResolve(); });',
+			options: [{ asyncMatchers: undefined }],
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 30,
+					line: 1,
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).toReject(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).toReject(); });',
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 30,
+					line: 1,
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).not.toReject(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).not.toReject(); });',
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 30,
+					line: 1,
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+			errors: [
+				{
+					column: 30,
+					endColumn: 83,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.toBeDefined(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.toBeDefined(); });',
+			errors: [
+				{
+					column: 30,
+					endColumn: 78,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
+			errors: [
+				{
+					column: 30,
+					endColumn: 82,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+			errors: [
+				{
+					column: 36,
+					endColumn: 85,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+			errors: [
+				{
+					column: 36,
+					endColumn: 89,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.reject(2)).toRejectWith(2); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.reject(2)).toRejectWith(2); });',
+			options: [{ asyncMatchers: ['toRejectWith'] }],
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 30,
+				},
+			],
+		},
+		{
+			code: 'test("valid-expect", () => { expect(Promise.reject(2)).rejects.toBe(2); });',
+			output:
+				'test("valid-expect", async () => { await expect(Promise.reject(2)).rejects.toBe(2); });',
+			options: [{ asyncMatchers: ['toRejectWith'] }],
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 30,
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", async () => {
       expect(Promise.resolve(2)).resolves.not.toBeDefined();
       expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      output: `
+			output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       await expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      errors: [
-        {
-          line: 3,
-          column: 7,
-          endColumn: 60,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-        {
-          line: 4,
-          column: 7,
-          endColumn: 55,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 3,
+					column: 7,
+					endColumn: 60,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+				{
+					line: 4,
+					column: 7,
+					endColumn: 55,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      output: `
+			output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       await expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      errors: [
-        {
-          line: 4,
-          column: 7,
-          endColumn: 55,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 4,
+					column: 7,
+					endColumn: 55,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", async () => {
       expect(Promise.resolve(2)).resolves.not.toBeDefined();
       return expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      output: `
+			output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       await expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      options: [{ alwaysAwait: true }],
-      errors: [
-        {
-          line: 3,
-          column: 7,
-          endColumn: 60,
-          messageId: 'asyncMustBeAwaited',
-        },
-        {
-          line: 4,
-          column: 14,
-          endColumn: 62,
-          messageId: 'asyncMustBeAwaited',
-        },
-      ],
-    },
-    {
-      code: `
+			options: [{ alwaysAwait: true }],
+			errors: [
+				{
+					line: 3,
+					column: 7,
+					endColumn: 60,
+					messageId: 'asyncMustBeAwaited',
+				},
+				{
+					line: 4,
+					column: 14,
+					endColumn: 62,
+					messageId: 'asyncMustBeAwaited',
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", async () => {
       expect(Promise.resolve(2)).resolves.not.toBeDefined();
       return expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      output: `
+			output: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(2)).resolves.not.toBeDefined();
       return expect(Promise.resolve(1)).rejects.toBeDefined();
        });
      `,
-      errors: [
-        {
-          line: 3,
-          column: 7,
-          endColumn: 60,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 3,
+					column: 7,
+					endColumn: 60,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", () => {
       Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
        });
      `,
-      output: `
+			output: `
        test("valid-expect", async () => {
       await Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
        });
      `,
-      errors: [
-        {
-          line: 3,
-          column: 7,
-          endColumn: 71,
-          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 3,
+					column: 7,
+					endColumn: 71,
+					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
      test("valid-expect", () => {
        Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
      });
       `,
-      output: `
+			output: `
      test("valid-expect", async () => {
        await Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
      });
       `,
-      options: [{ alwaysAwait: true }],
-      errors: [
-        {
-          line: 3,
-          column: 8,
-          endColumn: 78,
-          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-        },
-      ],
-    },
-    {
-      code: `
+			options: [{ alwaysAwait: true }],
+			errors: [
+				{
+					line: 3,
+					column: 8,
+					endColumn: 78,
+					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+				},
+			],
+		},
+		{
+			code: `
      test("valid-expect", () => {
       Promise.all([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -887,7 +878,7 @@ ruleTester.run(rule.name, rule, {
       ]);
        });
        `,
-      output: `
+			output: `
      test("valid-expect", async () => {
       await Promise.all([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -895,45 +886,45 @@ ruleTester.run(rule.name, rule, {
       ]);
        });
        `,
-      errors: [
-        {
-          line: 3,
-          column: 7,
-          endLine: 6,
-          endColumn: 9,
-          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 3,
+					column: 7,
+					endLine: 6,
+					endColumn: 9,
+					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
      test("valid-expect", () => {
       Promise.x([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
         expect(Promise.resolve(3)).resolves.not.toBeDefined(),
       ]);
        });`,
-      output: `
+			output: `
      test("valid-expect", async () => {
       await Promise.x([
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
         expect(Promise.resolve(3)).resolves.not.toBeDefined(),
       ]);
        });`,
-      errors: [
-        {
-          line: 3,
-          column: 7,
-          endLine: 6,
-          endColumn: 9,
-          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 3,
+					column: 7,
+					endLine: 6,
+					endColumn: 9,
+					messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", () => {
       const assertions = [
         expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -941,7 +932,7 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-      output: `
+			output: `
        test("valid-expect", async () => {
       const assertions = [
         await expect(Promise.resolve(2)).resolves.not.toBeDefined(),
@@ -949,27 +940,27 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-      errors: [
-        {
-          line: 4,
-          column: 9,
-          endLine: 4,
-          endColumn: 62,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-        {
-          line: 5,
-          column: 9,
-          endLine: 5,
-          endColumn: 62,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 4,
+					column: 9,
+					endLine: 4,
+					endColumn: 62,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+				{
+					line: 5,
+					column: 9,
+					endLine: 5,
+					endColumn: 62,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
      test("valid-expect", () => {
        const assertions = [
       expect(Promise.resolve(2)).toResolve(),
@@ -977,7 +968,7 @@ ruleTester.run(rule.name, rule, {
        ]
      });
       `,
-      output: `
+			output: `
      test("valid-expect", async () => {
        const assertions = [
       await expect(Promise.resolve(2)).toResolve(),
@@ -985,23 +976,23 @@ ruleTester.run(rule.name, rule, {
        ]
      });
       `,
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 7,
-          line: 4,
-        },
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 7,
-          line: 5,
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 7,
+					line: 4,
+				},
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 7,
+					line: 5,
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", () => {
       const assertions = [
         expect(Promise.resolve(2)).not.toResolve(),
@@ -1009,7 +1000,7 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-      output: `
+			output: `
        test("valid-expect", async () => {
       const assertions = [
         await expect(Promise.resolve(2)).not.toResolve(),
@@ -1017,59 +1008,59 @@ ruleTester.run(rule.name, rule, {
       ]
        });
      `,
-      errors: [
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 9,
-          line: 4,
-        },
-        {
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-          column: 9,
-          line: 5,
-        },
-      ],
-    },
-    {
-      code: 'expect(Promise.resolve(2)).resolves.toBe;',
-      errors: [
-        {
-          column: 37,
-          endColumn: 41,
-          messageId: 'matcherNotCalled',
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 9,
+					line: 4,
+				},
+				{
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+					column: 9,
+					line: 5,
+				},
+			],
+		},
+		{
+			code: 'expect(Promise.resolve(2)).resolves.toBe;',
+			errors: [
+				{
+					column: 37,
+					endColumn: 41,
+					messageId: 'matcherNotCalled',
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
         expect(Promise.resolve(2)).resolves.toBe(1);
       });
        });
      `,
-      output: `
+			output: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
         await expect(Promise.resolve(2)).resolves.toBe(1);
       });
        });
      `,
-      errors: [
-        {
-          line: 4,
-          column: 9,
-          endLine: 4,
-          endColumn: 52,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 4,
+					column: 9,
+					endLine: 4,
+					endColumn: 52,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
         await expect(Promise.resolve(2)).resolves.toBe(1);
@@ -1077,7 +1068,7 @@ ruleTester.run(rule.name, rule, {
       });
        });
      `,
-      output: `
+			output: `
        test("valid-expect", () => {
       return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
         await expect(Promise.resolve(2)).resolves.toBe(1);
@@ -1085,48 +1076,43 @@ ruleTester.run(rule.name, rule, {
       });
        });
      `,
-      errors: [
-        {
-          line: 5,
-          column: 9,
-          endLine: 5,
-          endColumn: 52,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-    {
-      code: `
+			errors: [
+				{
+					line: 5,
+					column: 9,
+					endLine: 5,
+					endColumn: 52,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+		{
+			code: `
        test("valid-expect", async () => {
       await expect(Promise.resolve(1));
        });
      `,
-      errors: [{ endColumn: 39, column: 13, messageId: 'matcherNotFound' }],
-    },
-    // N1 (issue #904): unawaited async assertion chained with .finally() is still flagged
-    // after the fix. The chain walker now treats .finally() as part of the chain (same
-    // as .then()/.catch()), so the reported range covers the whole chain instead of
-    // stopping before .finally(). The pair of reports/inserts mirrors the long-standing
-    // behavior on .then()/.catch() chains and is independent of this fix.
-    {
-      code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
-      output:
-        'test("valid-expect", async () => { await await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
-      errors: [
-        {
-          column: 36,
-          endColumn: 127,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-        {
-          column: 36,
-          endColumn: 127,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
-      ],
-    },
-  ],
+			errors: [{ endColumn: 39, column: 13, messageId: 'matcherNotFound' }],
+		},
+		{
+			code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+			output:
+				'test("valid-expect", async () => { await await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+			errors: [
+				{
+					column: 36,
+					endColumn: 127,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+				{
+					column: 36,
+					endColumn: 127,
+					messageId: 'asyncMustBeAwaited',
+					data: { orReturned: ' or returned' },
+				},
+			],
+		},
+	],
 })


### PR DESCRIPTION
Fixes #904.

`valid-expect` walks the surrounding promise chain via `getParentIfThenified` to decide whether the inner async assertion is already covered by an `await` or `return` higher up. The walker only recognised `.then()` and `.catch()` as chain links, so a chain ending in `.finally()` would have its inner `expect(...).resolves.X` reported as not awaited even when the whole chain is awaited.

This adds `'finally'` to the chain-link list at [`src/rules/valid-expect.ts`](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/src/rules/valid-expect.ts#L77). `Promise.prototype.finally` returns the same promise the chain awaits, so the await still propagates and the inner assertion does not need its own.

## Tests

`tests/valid-expect.test.ts` gets 8 new `valid` entries and 1 new `invalid` entry covering both axes of the fix:

Positive (return-form + await-form, await is honored when chain ends in `.finally()`)
- `.finally()` directly after the async assertion
- `.then()` then `.finally()`

Edge
- `.then()` then `.finally()` then `.then()` (deep nesting)
- `rejects.not.toBeDefined().finally(...)` (rejects path)
- `.finally()` before `.catch()` (mixed order)
- Two `.finally()` calls in a row
- `.catch()` then `.finally()`
- `.finally()` directly after the async assertion (await-form)

Negative (chain without an outer await is still flagged)
- `expect(...).resolves.not.toBeDefined().finally(...)` without `await` reports `asyncMustBeAwaited`

The negative test demonstrates a long-standing rule behavior on matcher chains that is independent of this fix: the rule pushes one descriptor for the inner matcher visit and one for the outer chain visit, so the chain receives two reports and the auto-fix inserts `await ` twice. The same pattern already affects `.then()` and `.catch()` chains. If you want the deduplication addressed, that can be a separate PR.

## Verification

```
pnpm test
# 2261 passed (130 in valid-expect.test.ts)

pnpm typecheck
# clean

pnpm lint:js
# clean

pnpm format
# All matched files use Prettier code style!
```

Opened as draft until CI is green.
