### PR TITLE
docs(no-large-snapshots): describe `allowSnapshots` as a map

### DIFF
--- a/docs/rules/no-large-snapshots.md
+++ b/docs/rules/no-large-snapshots.md
@@ -14,11 +14,11 @@ This rule aims to prevent large snapshots.
 
 <!-- begin auto-generated rule options list -->
 
-| Name               | Description                                            | Type   |
-| :----------------- | :----------------------------------------------------- | :----- |
-| `allowedSnapshots` | Allowed snapshot names by absolute snapshot file path. | Object |
-| `inlineMaxSize`    | Maximum number of lines allowed in inline snapshots.   | Number |
-| `maxSize`          | Maximum number of lines allowed in external snapshots. | Number |
+| Name               | Description                                                                                                                                                          | Type   |
+| :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----- |
+| `allowedSnapshots` | A map of snapshot absolute file paths to arrays of snapshot names that are allowed to exceed the size limit. Snapshot names can be specified as regular expressions. | Object |
+| `inlineMaxSize`    | Maximum number of lines allowed in inline snapshots.                                                                                                                 | Number |
+| `maxSize`          | Maximum number of lines allowed in external snapshots.                                                                                                               | Number |
 
 <!-- end auto-generated rule options list -->
 
@@ -26,7 +26,7 @@ This rule accepts an object with the following properties:
 
 - `maxSize` (default: `50`): The maximum size of a snapshot.
 - `inlineMaxSize` (default: `0`): The maximum size of a snapshot when it is inline.
-- `allowedSnapshots` (default: `[]`): The list of allowed snapshots.
+- `allowedSnapshots` (default: `{}`): The list of allowed snapshots.
 
 ### For example:
 
@@ -37,7 +37,7 @@ This rule accepts an object with the following properties:
     {
       "maxSize": 50,
       "inlineMaxSize": 0,
-      "allowedSnapshots": []
+      "allowedSnapshots": {}
     }
   ]
 }

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -1,5 +1,5 @@
-import { isAbsolute } from 'node:path'
 import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils'
+import { isAbsolute } from 'node:path'
 import {
   createEslintRule,
   getAccessorValue,
@@ -95,7 +95,7 @@ export default createEslintRule<[RuleOptions], MESSAGE_IDS>({
           },
           allowedSnapshots: {
             description:
-              'Allowed snapshot names by absolute snapshot file path.',
+              'A map of snapshot absolute file paths to arrays of snapshot names that are allowed to exceed the size limit. Snapshot names can be specified as regular expressions.',
             type: 'object',
             additionalProperties: { type: 'array' },
           },


### PR DESCRIPTION
The description of `allowedSnapshots` did not mention that it is a map of list values.
Still aligns how `jest` does it:
https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-large-snapshots.md

Aligns more how the type is defined internally:
https://github.com/vitest-dev/eslint-plugin-vitest/blob/28bc45fa548f4a88c50441db61de95fd27108daa/src/rules/no-large-snapshots.ts#L17
