### PR TITLE
fix: support Chai-style expect chains

### DIFF
--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -66,6 +66,36 @@ const getNormalizeFunctionExpression = (
   return functionExpression
 }
 
+const promiseChainMethods = new Set(['catch', 'finally', 'then'])
+
+const findTopMostMatcherCallExpression = (
+  node: TSESTree.CallExpression,
+): TSESTree.CallExpression => {
+  let currentNode: TSESTree.Node = node
+  let topMostMatcherCallExpression = node
+
+  while (
+    currentNode.parent?.type === AST_NODE_TYPES.MemberExpression &&
+    currentNode.parent.object === currentNode &&
+    isSupportedAccessor(currentNode.parent.property)
+  ) {
+    if (promiseChainMethods.has(getAccessorValue(currentNode.parent.property)))
+      break
+
+    currentNode = currentNode.parent
+
+    if (
+      currentNode.parent?.type === AST_NODE_TYPES.CallExpression &&
+      currentNode.parent.callee === currentNode
+    ) {
+      topMostMatcherCallExpression = currentNode.parent
+      currentNode = currentNode.parent
+    }
+  }
+
+  return topMostMatcherCallExpression
+}
+
 function getParentIfThenified(node: TSESTree.Node): TSESTree.Node {
   const grandParentNode = node.parent?.parent
 
@@ -74,7 +104,7 @@ function getParentIfThenified(node: TSESTree.Node): TSESTree.Node {
     grandParentNode.type === AST_NODE_TYPES.CallExpression &&
     grandParentNode.callee.type === AST_NODE_TYPES.MemberExpression &&
     isSupportedAccessor(grandParentNode.callee.property) &&
-    ['then', 'catch', 'finally'].includes(
+    promiseChainMethods.has(
       getAccessorValue(grandParentNode.callee.property),
     ) &&
     grandParentNode.parent
@@ -281,12 +311,6 @@ export default createEslintRule<
           return
         } else if (vitestFnCall?.type !== 'expect') {
           return
-        } else if (
-          vitestFnCall.modifiers.some(
-            (mod) => mod.type === AST_NODE_TYPES.Identifier && mod.name == 'to',
-          )
-        ) {
-          return
         }
 
         const { parent: expect } = vitestFnCall.head.node
@@ -352,11 +376,21 @@ export default createEslintRule<
 
         const { matcher } = vitestFnCall
 
-        const parentNode = matcher.parent.parent
+        const matcherCallExpression = matcher.parent.parent
+
+        if (matcherCallExpression.type !== AST_NODE_TYPES.CallExpression) return
+
+        const parentNode = findTopMostMatcherCallExpression(
+          matcherCallExpression,
+        )
         const shouldBeAwaited =
-          vitestFnCall.modifiers.some(
-            (nod) => getAccessorValue(nod) !== 'not',
-          ) || asyncMatchers.includes(getAccessorValue(matcher))
+          vitestFnCall.modifiers.some((modifier) => {
+            const value = getAccessorValue(modifier)
+
+            return (
+              value === ModifierName.resolves || value === ModifierName.rejects
+            )
+          }) || asyncMatchers.includes(getAccessorValue(matcher))
 
         if (!parentNode?.parent || !shouldBeAwaited) return
 

--- a/src/utils/parse-vitest-fn-call.ts
+++ b/src/utils/parse-vitest-fn-call.ts
@@ -55,6 +55,14 @@ interface ModifiersAndMatcher {
   args: TSESTree.CallExpression['arguments']
 }
 
+type ExpectChainKind = 'language-chain' | 'modifier' | 'matcher' | 'unknown'
+
+interface ExpectChain {
+  kind: ExpectChainKind
+  member: KnownMemberExpressionProperty
+  callExpression: TSESTree.CallExpression | null
+}
+
 interface BaseParsedVitestFnCall {
   /**
    * The name of the underlying Vitest function that is being called.
@@ -138,70 +146,241 @@ const determineVitestFnType = (name: string): VitestFnType => {
   return 'unknown'
 }
 
-const findModifiersAndMatcher = (
-  members: KnownMemberExpressionProperty[],
-): ModifiersAndMatcher | Reason => {
-  const modifiers: KnownMemberExpressionProperty[] = []
+const hasInvalidExpectChain = (
+  chains: ExpectChain[],
+  matcherIndex: number,
+): boolean => {
+  const modifierChains =
+    matcherIndex === -1 ? chains : chains.slice(0, matcherIndex)
 
-  for (const member of members) {
-    // check if the member is being called, which means it is the matcher
-    // (and also the end of the entire "expect" call chain)
-    if (
-      member.parent?.type === AST_NODE_TYPES.MemberExpression &&
-      member.parent.parent?.type === AST_NODE_TYPES.CallExpression
-    ) {
-      return {
-        matcher: member,
-        args: member.parent.parent.arguments,
-        modifiers,
-      }
-    }
+  if (
+    modifierChains.some(
+      (chain) =>
+        chain.kind === 'unknown' ||
+        (chain.kind !== 'matcher' && chain.callExpression),
+    )
+  )
+    return true
 
-    // otherwise, it should be a modifier
-    const name = getAccessorValue(member)
+  const modifierNames = modifierChains
+    .filter((chain) => chain.kind === 'modifier')
+    .map((chain) => getAccessorValue(chain.member))
 
-    if (modifiers.length === 0) {
-      // the first modifier can be any of the three modifiers
-      if (!Object.prototype.hasOwnProperty.call(ModifierName, name))
-        return 'modifier-unknown'
-    } else if (modifiers.length === 1) {
-      // the second modifier can only either be "not" or "have"
-      if (name !== ModifierName.not && name != ModifierName.have)
-        return 'modifier-unknown'
+  if (modifierNames.filter((name) => name === ModifierName.not).length > 1)
+    return true
 
-      const firstModifier = getAccessorValue(modifiers[0])
-
-      // and the first modifier has to be either "resolves" or "rejects" or "to"
-      if (
-        firstModifier !== ModifierName.resolves &&
-        firstModifier !== ModifierName.rejects &&
-        firstModifier !== ModifierName.to
-      )
-        return 'modifier-unknown'
-    } else {
-      return 'modifier-unknown'
-    }
-    modifiers.push(member)
-  }
-
-  // this will only really happen if there are no members
-  return 'matcher-not-found'
-}
-
-const parseVitestExpectCall = (
-  typelessParsedVitestFnCall: Omit<ParsedVitestFnCall, 'type'>,
-  type: 'expect' | 'expectTypeOf',
-): ParsedExpectVitestFnCall | Reason => {
-  const modifiersMatcher = findModifiersAndMatcher(
-    typelessParsedVitestFnCall.members,
+  const promiseModifierNames = modifierNames.filter((name) =>
+    promiseExpectModifiers.has(name),
   )
 
-  if (typeof modifiersMatcher === 'string') return modifiersMatcher
+  if (promiseModifierNames.length > 1) return true
+
+  return !chains
+    .slice(matcherIndex + 1)
+    .every(
+      (chain) =>
+        chain.kind !== 'unknown' &&
+        (chain.kind === 'matcher' || !chain.callExpression),
+    )
+}
+
+const chaiLanguageChainProperties = new Set([
+  'also',
+  'and',
+  'at',
+  'be',
+  'been',
+  'but',
+  'does',
+  'has',
+  'have',
+  'is',
+  'itself',
+  'of',
+  'same',
+  'still',
+  'that',
+  'to',
+  'which',
+  'with',
+])
+
+const chaiFlagChainProperties = new Set([
+  'all',
+  'any',
+  'deep',
+  'nested',
+  'ordered',
+  'own',
+])
+
+const chaiDualRoleChainProperties = new Set([
+  'a',
+  'an',
+  'contain',
+  'contains',
+  'include',
+  'includes',
+  'length',
+  'lengthOf',
+  'respondTo',
+])
+
+const chaiChainableProperties = new Set([
+  ...chaiLanguageChainProperties,
+  ...chaiFlagChainProperties,
+  ...chaiDualRoleChainProperties,
+])
+
+const expectModifiers = new Set<string>([
+  ModifierName.not,
+  ModifierName.rejects,
+  ModifierName.resolves,
+])
+
+const promiseExpectModifiers = new Set<string>([
+  ModifierName.rejects,
+  ModifierName.resolves,
+])
+
+const expectTypeOfModifiers = new Set<string>([
+  ModifierName.not,
+  ModifierName.resolves,
+  ModifierName.returns,
+  ModifierName.branded,
+  ModifierName.asserts,
+  ModifierName.constructorParameters,
+  ModifierName.parameters,
+  ModifierName.thisParameter,
+  ModifierName.guards,
+  ModifierName.instance,
+  ModifierName.items,
+])
+
+const getCallExpression = (
+  member: KnownMemberExpressionProperty,
+): TSESTree.CallExpression | null =>
+  member.parent?.type === AST_NODE_TYPES.MemberExpression &&
+  member.parent.parent?.type === AST_NODE_TYPES.CallExpression &&
+  member.parent.parent.callee === member.parent
+    ? member.parent.parent
+    : null
+
+const classifyExpectChain = (
+  member: KnownMemberExpressionProperty,
+): ExpectChain => {
+  const name = getAccessorValue(member)
+  const callExpression = getCallExpression(member)
+
+  if (callExpression) {
+    if (
+      expectModifiers.has(name) ||
+      (chaiChainableProperties.has(name) &&
+        !chaiDualRoleChainProperties.has(name))
+    )
+      return { kind: 'language-chain', member, callExpression }
+
+    return { kind: 'matcher', member, callExpression }
+  }
+
+  if (chaiChainableProperties.has(name))
+    return { kind: 'language-chain', member, callExpression }
+
+  if (!expectModifiers.has(name))
+    return { kind: 'unknown', member, callExpression }
+
+  return { kind: 'modifier', member, callExpression }
+}
+
+const parseExpectCallExpression = (
+  node: TSESTree.CallExpression,
+  topMostCallExpression: TSESTree.CallExpression,
+  typeLessParsedVitestFnCall: Omit<ParsedVitestFnCall, 'type'>,
+): ParsedExpectVitestFnCall | Reason | null => {
+  const chains = typeLessParsedVitestFnCall.members.map(classifyExpectChain)
+  const matcherIndex = chains.findIndex((chain) => chain.kind === 'matcher')
+
+  if (
+    node.parent?.type === AST_NODE_TYPES.MemberExpression &&
+    topMostCallExpression !== node
+  )
+    return null
+
+  if (hasInvalidExpectChain(chains, matcherIndex)) return 'modifier-unknown'
+
+  if (matcherIndex === -1) {
+    if (node.parent?.type === AST_NODE_TYPES.MemberExpression)
+      return 'matcher-not-called'
+
+    return 'matcher-not-found'
+  }
+
+  const modifierChains = chains.slice(0, matcherIndex)
+  const matcher = chains[matcherIndex]
 
   return {
-    ...typelessParsedVitestFnCall,
-    type,
-    ...modifiersMatcher,
+    ...typeLessParsedVitestFnCall,
+    type: 'expect',
+    members: typeLessParsedVitestFnCall.members.slice(0, matcherIndex + 1),
+    matcher: matcher.member,
+    args: matcher.callExpression?.arguments ?? [],
+    modifiers: modifierChains
+      .filter((chain) => chain.kind === 'modifier')
+      .map((chain) => chain.member),
+  }
+}
+
+const parseExpectTypeOfCallExpression = (
+  node: TSESTree.CallExpression,
+  topMostCallExpression: TSESTree.CallExpression,
+  typeLessParsedVitestFnCall: Omit<ParsedVitestFnCall, 'type'>,
+): ParsedExpectVitestFnCall | Reason | null => {
+  const matcherIndex = typeLessParsedVitestFnCall.members.findIndex((member) =>
+    getCallExpression(member),
+  )
+  const modifierMembers =
+    matcherIndex === -1
+      ? typeLessParsedVitestFnCall.members
+      : typeLessParsedVitestFnCall.members.slice(0, matcherIndex)
+  const modifierNames = modifierMembers.map(getAccessorValue)
+
+  if (
+    node.parent?.type === AST_NODE_TYPES.MemberExpression &&
+    topMostCallExpression !== node
+  )
+    return null
+
+  if (
+    modifierMembers.some(
+      (member) => !expectTypeOfModifiers.has(getAccessorValue(member)),
+    ) ||
+    modifierNames.filter((name) => name === ModifierName.not).length > 1 ||
+    (matcherIndex !== -1 &&
+      expectTypeOfModifiers.has(
+        getAccessorValue(typeLessParsedVitestFnCall.members[matcherIndex]),
+      ))
+  ) {
+    return 'modifier-unknown'
+  }
+
+  if (matcherIndex === -1) {
+    if (node.parent?.type === AST_NODE_TYPES.MemberExpression)
+      return 'matcher-not-called'
+
+    return 'matcher-not-found'
+  }
+
+  const matcher = typeLessParsedVitestFnCall.members[matcherIndex]
+  const callExpression = getCallExpression(matcher)
+
+  if (!callExpression) return null
+
+  return {
+    ...typeLessParsedVitestFnCall,
+    type: 'expectTypeOf',
+    matcher,
+    args: callExpression.arguments,
+    modifiers: modifierMembers,
   }
 }
 
@@ -281,16 +460,19 @@ const parseVitestFnCallWithReasonInner = (
   const type = determineVitestFnType(name)
 
   if (type === 'expect' || type === 'expectTypeOf') {
-    const result = parseVitestExpectCall(parsedVitestFnCall, type)
+    const topMostCallExpression = findTopMostCallExpression(node)
 
-    if (typeof result === 'string' && findTopMostCallExpression(node) !== node)
-      return null
-
-    if (result === 'matcher-not-found') {
-      if (node.parent?.type === AST_NODE_TYPES.MemberExpression)
-        return 'matcher-not-called'
-    }
-    return result
+    return type === 'expect'
+      ? parseExpectCallExpression(
+          node,
+          topMostCallExpression,
+          parsedVitestFnCall,
+        )
+      : parseExpectTypeOfCallExpression(
+          node,
+          topMostCallExpression,
+          parsedVitestFnCall,
+        )
   }
 
   if (

--- a/tests/max-expects.test.ts
+++ b/tests/max-expects.test.ts
@@ -97,6 +97,22 @@ ruleTester.run(rule.name, rule, {
         },
       ],
     },
+    {
+      code: `test('should not pass', () => {
+      expect(true).toBeDefined();
+      expect("hey").to.be.a("string");
+       });`,
+      options: [
+        {
+          max: 1,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'maxExpect',
+        },
+      ],
+    },
   ],
 })
 

--- a/tests/no-alias-methods.test.ts
+++ b/tests/no-alias-methods.test.ts
@@ -16,6 +16,7 @@ ruleTester.run(rule.name, rule, {
     'expect(a).toThrow()',
     'expect(a).rejects;',
     'expect(a);',
+    'expect(a).to.be.a("string");',
   ],
   invalid: [
     {

--- a/tests/no-conditional-expect.test.ts
+++ b/tests/no-conditional-expect.test.ts
@@ -63,6 +63,16 @@ ruleTester.run(`${rule.name}-logical conditions`, rule, {
     },
     {
       code: ` it('foo', () => {
+      something && expect(something).to.be.a("string");
+       })`,
+      errors: [
+        {
+          messageId: 'noConditionalExpect',
+        },
+      ],
+    },
+    {
+      code: ` it('foo', () => {
       a || (b && expect(something).toHaveBeenCalled());
        })`,
       errors: [

--- a/tests/no-restricted-matchers.test.ts
+++ b/tests/no-restricted-matchers.test.ts
@@ -41,6 +41,10 @@ ruleTester.run(rule.name, rule, {
       code: 'expect(a).resolves.not.toBe(b)',
       options: [{ 'not.toBe': null }],
     },
+    {
+      code: 'expect(a).to.be.a("string").and.contain("hell")',
+      options: [{ contain: null }],
+    },
   ],
   invalid: [
     {
@@ -55,6 +59,45 @@ ruleTester.run(rule.name, rule, {
           },
           column: 11,
           line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(a).not.to.be.a("string")',
+      options: [{ not: null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            restriction: 'not',
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect(a).to.be.a("string")',
+      options: [{ 'to.be.a': null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            restriction: 'to.be.a',
+          },
+        },
+      ],
+    },
+    {
+      code: 'expect(a).to.be.a("string").and.contain("hell")',
+      options: [{ 'to.be.a': null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            restriction: 'to.be.a',
+          },
         },
       ],
     },

--- a/tests/no-standalone-expect.test.ts
+++ b/tests/no-standalone-expect.test.ts
@@ -98,6 +98,10 @@ ruleTester.run(rule.name, rule, {
       errors: [{ endColumn: 19, column: 2, messageId: 'noStandaloneExpect' }],
     },
     {
+      code: 'expect("hey").to.be.a("string");',
+      errors: [{ messageId: 'noStandaloneExpect' }],
+    },
+    {
       code: `
      each([
        [1, 1, 2],

--- a/tests/prefer-comparison-matcher.test.ts
+++ b/tests/prefer-comparison-matcher.test.ts
@@ -9,6 +9,7 @@ ruleTester.run(rule.name, rule, {
     'expect(true).toBe(...true)',
     'expect()',
     'expect({}).toStrictEqual({})',
+    'expect(a).to.be.a("string");',
     'expect(a === b).toBe(true)',
     'expect(a !== 2).toStrictEqual(true)',
     'expect(a === b).not.toEqual(true)',

--- a/tests/prefer-equality-matcher.test.ts
+++ b/tests/prefer-equality-matcher.test.ts
@@ -27,6 +27,7 @@ ruleTester.run(rule.name, rule, {
     'expect.hasAssertions()',
     'expect.assertions(1)',
     'expect(true).toBe(...true)',
+    'expect(a).to.be.a("string");',
     'expect(a == 1).toBe(true)',
     'expect(1 == a).toBe(true)',
     'expect(a == b).toBe(true)',

--- a/tests/prefer-expect-assertions.test.ts
+++ b/tests/prefer-expect-assertions.test.ts
@@ -173,6 +173,32 @@ it('my test description', (context) => {context.expect.assertions();
       ],
     },
     {
+      code: `it('checks value', () => {
+  expect(value).to.be.a("string")
+})`,
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestAddingHasAssertions',
+              output: `it('checks value', () => {expect.hasAssertions();
+  expect(value).to.be.a("string")
+})`,
+            },
+            {
+              messageId: 'suggestAddingAssertions',
+              output: `it('checks value', () => {expect.assertions();
+  expect(value).to.be.a("string")
+})`,
+            },
+          ],
+        },
+      ],
+    },
+    {
       code: 'it("it1", () => {})',
       errors: [
         {

--- a/tests/prefer-strict-boolean-matchers.test.ts
+++ b/tests/prefer-strict-boolean-matchers.test.ts
@@ -28,6 +28,7 @@ ruleTester.run(rule.name, rule, {
     'expect("a string").not.toMatchSnapshot();',
     "expect(something).toEqual('a string');",
     'expect(true).toBe',
+    'expect(value).to.be.a("boolean");',
     'expectTypeOf(true).toBe()',
   ],
   invalid: [

--- a/tests/prefer-strict-equal.test.ts
+++ b/tests/prefer-strict-equal.test.ts
@@ -4,6 +4,7 @@ import { ruleTester } from './ruleTester'
 ruleTester.run(rule.name, rule, {
   valid: [
     'expect(something).toStrictEqual(somethingElse);',
+    'expect(something).to.be.a("string");',
     "a().toEqual('b')",
     'expect(a);',
   ],

--- a/tests/prefer-to-be-falsy.test.ts
+++ b/tests/prefer-to-be-falsy.test.ts
@@ -7,6 +7,7 @@ ruleTester.run(rule.name, rule, {
   valid: [
     '[].push(false)',
     'expect("something");',
+    'expect(value).to.be.a("boolean");',
     'expect(true).toBeTrue();',
     'expect(false).toBeTrue();',
     'expect(false).toBeFalsy();',

--- a/tests/prefer-to-be-object.test.ts
+++ b/tests/prefer-to-be-object.test.ts
@@ -16,6 +16,7 @@ ruleTester.run(rule.name, rule, {
     'expectTypeOf({}).not.toBeObject()',
     'expectTypeOf([] instanceof Array).not.toBeObject()',
     'expectTypeOf({}).not.toBeInstanceOf(Array)',
+    'expect({}).to.be.a("object");',
   ],
   invalid: [
     {

--- a/tests/prefer-to-be-truthy.test.ts
+++ b/tests/prefer-to-be-truthy.test.ts
@@ -7,6 +7,7 @@ ruleTester.run(rule.name, rule, {
   valid: [
     '[].push(true)',
     'expect("something");',
+    'expect(value).to.be.a("boolean");',
     'expect(true).toBeTrue();',
     'expect(false).toBeTrue();',
     'expect(fal,se).toBeFalse();',

--- a/tests/prefer-to-be.test.ts
+++ b/tests/prefer-to-be.test.ts
@@ -13,6 +13,7 @@ ruleTester.run(rule.name, rule, {
     'expect(value).toMatchSnapshot();',
     "expect(catchError()).toStrictEqual({ message: 'oh noes!' })",
     'expect("something");',
+    'expect("hey").to.be.a("string");',
     'expect(token).toStrictEqual(/[abc]+/g);',
     "expect(token).toStrictEqual(new RegExp('[abc]+', 'g'));",
     'expect(0.1 + 0.2).toEqual(0.3);',

--- a/tests/prefer-to-contain.test.ts
+++ b/tests/prefer-to-contain.test.ts
@@ -28,6 +28,7 @@ ruleTester.run(rule.name, rule, {
     'expect(a.includes(...[])).toBe(true)',
     'expect(a.includes(b)).toBe(...true)',
     'expect(a);',
+    'expect(a).to.be.a("string");',
   ],
   invalid: [
     {

--- a/tests/prefer-to-have-length.test.ts
+++ b/tests/prefer-to-have-length.test.ts
@@ -8,6 +8,7 @@ ruleTester.run(rule.name, rule, {
     'expect.hasAssertions',
     'expect.hasAssertions()',
     'expect(files).toHaveLength(1);',
+    'expect(files).to.be.a("array");',
     "expect(files.name).toBe('file');",
     "expect(files[`name`]).toBe('file');",
     'expect(users[0]?.permissions?.length).toBe(1);',

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -11,6 +11,8 @@ ruleTester.run(rule.name, rule, {
     'expect(undefined).not.toBeDefined();',
     'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.toBeDefined(); });',
     'test("valid-expect", () => { return expect(Promise.reject(2)).rejects.toBeDefined(); });',
+    'test("valid-expect", async () => { await expect(Promise.resolve(2)).not.resolves.toBeDefined(); });',
+    'test("valid-expect", async () => { await expect(Promise.reject(2)).not.rejects.toBeDefined(); });',
     'test("valid-expect", () => { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
     'test("valid-expect", () => { return expect(Promise.resolve(2)).rejects.not.toBeDefined(); });',
     'test("valid-expect", function () { return expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
@@ -100,6 +102,66 @@ ruleTester.run(rule.name, rule, {
 `,
     `it('example', () => {
    expect("hey").to.have.property("foo", "bar")
+});
+`,
+    `it('example', () => {
+   expect("hey").to.be.a("string")
+});
+`,
+    `it('example', () => {
+   expect("hello").to.be.a("string").and.contain("hell")
+});
+`,
+    `it('example', () => {
+   expect([1, 2, 3]).to.include.members([1, 2])
+});
+`,
+    `it('example', () => {
+   expect([1, 2, 3]).to.have.lengthOf.above(2)
+});
+`,
+    `it('example', () => {
+   expect([1, 2, 3]).to.have.lengthOf(3)
+});
+`,
+    `it('example', () => {
+   expect([1, 2, 3]).to.have.length.above(2)
+});
+`,
+    `it('example', () => {
+   expect(Foo).itself.to.respondTo("bar")
+});
+`,
+    `it('example', () => {
+   expect("hello").to.be.a("string").that.does.not.contain("world")
+});
+`,
+    `it('example', async () => {
+   await expect(Promise.resolve("hello")).resolves.to.be.a("string")
+});
+`,
+    `it('example', async () => {
+   await expect(Promise.resolve("hello")).resolves.to.be.a("string").and.contain("hell")
+});
+`,
+    `it('example', () => {
+   return expect(Promise.resolve("hello")).resolves.to.be.a("string").and.contain("hell")
+});
+`,
+    `it('example', () => {
+   expect("hello").not.to.be.an("array")
+});
+`,
+    `it('example', () => {
+   expect("hello").to.not.contain("world")
+});
+`,
+    `it('example', () => {
+   expect("hello").not.to.contain("world")
+});
+`,
+    `it('example', () => {
+   expect({ a: 1 }).to.deep.equal({ a: 1 })
 });
 `,
     {
@@ -192,6 +254,22 @@ ruleTester.run(rule.name, rule, {
     },
     {
       code: `expectTypeOf().items.toMatchTypeOf();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf(Promise.resolve(1)).resolves.toEqualTypeOf<number>();`,
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+    },
+    {
+      code: `expectTypeOf(Promise.resolve({ a: 1 })).resolves.not.toEqualTypeOf<string>();`,
       settings: {
         vitest: {
           typecheck: true,
@@ -420,13 +498,19 @@ ruleTester.run(rule.name, rule, {
     },
     {
       code: 'expect(true).not.resolves.toBeDefined();',
-      errors: [
-        {
-          endColumn: 40,
-          column: 1,
-          messageId: 'modifierUnknown',
-        },
-      ],
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
+    },
+    {
+      code: 'expect(true).not.rejects.toBeDefined();',
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
+    },
+    {
+      code: 'expect(Promise.resolve(1)).to.resolves.toBe(1);',
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
+    },
+    {
+      code: 'expect(Promise.reject(1)).to.rejects.toBe(1);',
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
     },
     {
       code: 'expect(true).not.not.toBeDefined();',
@@ -439,12 +523,45 @@ ruleTester.run(rule.name, rule, {
       ],
     },
     {
+      code: 'expectTypeOf(value).to.toMatchTypeOf();',
+      settings: {
+        vitest: {
+          typecheck: true,
+        },
+      },
+      errors: [{ messageId: 'modifierUnknown' }],
+    },
+    {
       code: 'expect(true).resolves.not.exactly.toBeDefined();',
       errors: [
         {
           endColumn: 48,
           column: 1,
           messageId: 'modifierUnknown',
+        },
+      ],
+    },
+    {
+      code: 'expect("hello").to.be("string").that.does.not.contain("world");',
+      errors: [{ messageId: 'modifierUnknown' }],
+    },
+    {
+      code: 'expect("hello").to.be.a("string").that.foo.not.contain("world");',
+      errors: [{ messageId: 'modifierUnknown' }],
+    },
+    {
+      code: 'expect().to.be.a("string");',
+      errors: [
+        {
+          messageId: 'notEnoughArgs',
+        },
+      ],
+    },
+    {
+      code: 'expect(value, badSecondArg).to.be.a("string");',
+      errors: [
+        {
+          messageId: 'tooManyArgs',
         },
       ],
     },
@@ -499,6 +616,14 @@ ruleTester.run(rule.name, rule, {
           data: { orReturned: ' or returned' },
         },
       ],
+    },
+    {
+      code: `expect(Promise.resolve("hey")).resolves.to.be.a("string")`,
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
+    },
+    {
+      code: `expect(Promise.resolve("hello")).resolves.to.be.a("string").and.contain("hell")`,
+      errors: [{ messageId: 'asyncMustBeAwaited' }],
     },
     {
       code: 'expect(Promise.resolve(2)).resolves.toBeDefined();',
@@ -1098,14 +1223,8 @@ ruleTester.run(rule.name, rule, {
     {
       code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
       output:
-        'test("valid-expect", async () => { await await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined().finally(() => console.log("cleanup")); });',
       errors: [
-        {
-          column: 36,
-          endColumn: 127,
-          messageId: 'asyncMustBeAwaited',
-          data: { orReturned: ' or returned' },
-        },
         {
           column: 36,
           endColumn: 127,


### PR DESCRIPTION
## Summary

Fixes #675 
Related to #919

This PR updates expect chain parsing to better support Vitest's Chai-style assertions and `not.resolves` / `not.rejects` chains.

## Details

Chai chain support in this PR is intentionally conservative.

For #675, valid Chai-style assertions are recognized so they are not reported as `modifierUnknown`:

```ts
expect(value).to.be.a('string')
expect(value).to.have.property('id')
```

At the same time, invalid called chains are still rejected:

```ts
expect(value).to.be('string')
```

For #919, `not.resolves` / `not.rejects` are parsed as async assertions instead of unknown modifier chains. Therefore, unawaited usages are reported as `asyncMustBeAwaited`:

```ts
expect(Promise.resolve(1)).not.resolves.toBe(2)
```

For chained Chai assertions with multiple matchers, the parser returns the result up to the first matcher. This keeps existing rule behavior stable because current consumers of `parseVitestFnCall` expect a single matcher.

A more complete solution would be to change the parser return type to represent multiple matchers, but that would require broader changes across all consumers of `parseVitestFnCall`, so this PR avoids that larger refactor.