### PR TITLE
fix: handle expect.any separately from Chai any flag

### DIFF
--- a/src/utils/parse-vitest-fn-call.ts
+++ b/src/utils/parse-vitest-fn-call.ts
@@ -268,11 +268,17 @@ const getCallExpression = (
 
 const classifyExpectChain = (
   member: KnownMemberExpressionProperty,
+  isFirstMemberOfStaticExpectCall = false,
 ): ExpectChain => {
   const name = getAccessorValue(member)
   const callExpression = getCallExpression(member)
 
   if (callExpression) {
+    // `expect.any(...)` is a static asymmetric matcher factory, not Chai's
+    // `.any` flag. Keep uncalled `.any` in Chai chains as a language chain.
+    if (isFirstMemberOfStaticExpectCall && name === 'any')
+      return { kind: 'matcher', member, callExpression }
+
     if (
       expectModifiers.has(name) ||
       (chaiChainableProperties.has(name) &&
@@ -297,7 +303,14 @@ const parseExpectCallExpression = (
   topMostCallExpression: TSESTree.CallExpression,
   typeLessParsedVitestFnCall: Omit<ParsedVitestFnCall, 'type'>,
 ): ParsedExpectVitestFnCall | Reason | null => {
-  const chains = typeLessParsedVitestFnCall.members.map(classifyExpectChain)
+  const chains = typeLessParsedVitestFnCall.members.map((member, index) =>
+    classifyExpectChain(
+      member,
+      index === 0 &&
+        typeLessParsedVitestFnCall.head.node.parent?.type ===
+          AST_NODE_TYPES.MemberExpression,
+    ),
+  )
   const matcherIndex = chains.findIndex((chain) => chain.kind === 'matcher')
 
   if (

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -5,6 +5,24 @@ ruleTester.run(rule.name, rule, {
   valid: [
     'expect.hasAssertions',
     'expect.hasAssertions()',
+    'expect.any(String)',
+    'expect.anything()',
+    'expect.arrayContaining([1])',
+    'expect.closeTo(1, 2)',
+    'expect.objectContaining({ id: 1 })',
+    'expect.schemaMatching(schema)',
+    'expect.stringContaining("value")',
+    'expect.stringMatching(/value/)',
+    'expect.toBeOneOf([1, 2])',
+    'expect.toSatisfy(value => value > 0)',
+    'expect.not.arrayContaining([1])',
+    'expect.not.closeTo(1, 2)',
+    'expect.not.objectContaining({ id: 1 })',
+    'expect.not.schemaMatching(schema)',
+    'expect.not.stringContaining("value")',
+    'expect.not.stringMatching(/value/)',
+    'expect.not.toBeOneOf([1, 2])',
+    'expect.not.toSatisfy(value => value > 0)',
     'expect("something").toEqual("else");',
     'expect(true).toBeDefined();',
     'expect([1, 2, 3]).toEqual([1, 2, 3]);',
@@ -162,6 +180,10 @@ ruleTester.run(rule.name, rule, {
 `,
     `it('example', () => {
    expect({ a: 1 }).to.deep.equal({ a: 1 })
+});
+`,
+    `it('example', () => {
+   expect({ a: 1 }).to.have.any.keys("a", "b")
 });
 `,
     {


### PR DESCRIPTION
Fixes #924

## Summary

This fixes a `valid-expect` regression introduced after Chai-style expect chain support in #920.

`expect.any(...)` was accidentally classified as Chai's `.any` flag because `any` is also a Chai chain property. As a result, `valid-expect` reported `Expect has an unknown modifier`.

This PR restores the pre-#920 behavior for called `expect.any(...)`, while keeping uncalled `.any` in Chai chains working:

```ts
expect.any(String) // expect.any(...)

expect(value).to.have.any.keys('a', 'b') // Chai `.any` flag
```

A broader parser change to distinguish asymmetric matcher factories from assertion matcher calls can be handled separately if needed.