### PR TITLE
feat(prefer-expect-assertions): add disallowHasAssertions option

### DIFF
--- a/docs/rules/prefer-expect-assertions.md
+++ b/docs/rules/prefer-expect-assertions.md
@@ -46,11 +46,12 @@ test('assertions first', () => {
 
 <!-- begin auto-generated rule options list -->
 
-| Name                                | Description                                                   | Type    |
-| :---------------------------------- | :------------------------------------------------------------ | :------ |
-| `onlyFunctionsWithAsyncKeyword`     | Only check test functions declared with the async keyword.    | Boolean |
-| `onlyFunctionsWithExpectInCallback` | Only check test functions that contain `expect` in callbacks. | Boolean |
-| `onlyFunctionsWithExpectInLoop`     | Only check test functions that contain `expect` inside loops. | Boolean |
+| Name                                | Description                                                                  | Type    |
+| :---------------------------------- | :--------------------------------------------------------------------------- | :------ |
+| `disallowHasAssertions`             | Warn when `expect.hasAssertions()` is used instead of `expect.assertions()`. | Boolean |
+| `onlyFunctionsWithAsyncKeyword`     | Only check test functions declared with the async keyword.                   | Boolean |
+| `onlyFunctionsWithExpectInCallback` | Only check test functions that contain `expect` in callbacks.                | Boolean |
+| `onlyFunctionsWithExpectInLoop`     | Only check test functions that contain `expect` inside loops.                | Boolean |
 
 <!-- end auto-generated rule options list -->
 
@@ -124,5 +125,28 @@ test('assertions first', () => {
   fetchData((data) => {
     expect(data).toBe('peanut butter')
   })
+})
+```
+
+`disallowHasAssertions` (default: `false`)
+
+When `true`, `expect.hasAssertions()` will be reported in favor of `expect.assertions()`.
+Suggestions for missing assertions will only include `expect.assertions()`.
+
+when this option is enabled the following code will be considered incorrect:
+
+```js
+test('has assertions', () => {
+  expect.hasAssertions()
+  expect(value).toBe(1)
+})
+```
+
+To fix this, use `expect.assertions(<number of assertions>)` instead:
+
+```js
+test('has assertions', () => {
+  expect.assertions(1)
+  expect(value).toBe(1)
 })
 ```

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -292,13 +292,15 @@ export default createEslintRule<Options[], MessageIds>({
         if (secondArg.body.type === AST_NODE_TYPES.BlockStatement) {
           const prefix = testContextName ? `${testContextName}.` : ''
           if (!options.disallowHasAssertions) {
-            suggestions.push(
-              ['suggestAddingHasAssertions', `${prefix}expect.hasAssertions();`],
-            )
+            suggestions.push([
+              'suggestAddingHasAssertions',
+              `${prefix}expect.hasAssertions();`,
+            ])
           }
-          suggestions.push(
-            ['suggestAddingAssertions', `${prefix}expect.assertions();`],
-          )
+          suggestions.push([
+            'suggestAddingAssertions',
+            `${prefix}expect.assertions();`,
+          ])
         }
 
         context.report({

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -19,6 +19,7 @@ type Options = {
   onlyFunctionsWithAsyncKeyword?: boolean
   onlyFunctionsWithExpectInLoop?: boolean
   onlyFunctionsWithExpectInCallback?: boolean
+  disallowHasAssertions?: boolean
 }
 
 const RULE_NAME = 'prefer-expect-assertions'
@@ -28,8 +29,10 @@ type MessageIds =
   | 'assertionsRequiresOneArgument'
   | 'assertionsRequiresNumberArgument'
   | 'haveExpectAssertions'
+  | 'preferAssertionsOverHasAssertions'
   | 'suggestAddingHasAssertions'
   | 'suggestAddingAssertions'
+  | 'suggestReplacingWithAssertions'
   | 'suggestRemovingExtraArguments'
 
 const isFirstStatement = (node: TSESTree.CallExpression): boolean => {
@@ -72,9 +75,13 @@ export default createEslintRule<Options[], MessageIds>({
       assertionsRequiresNumberArgument: 'This argument should be a number',
       haveExpectAssertions:
         'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression',
+      preferAssertionsOverHasAssertions:
+        'Prefer `expect.assertions(<number of assertions>)` over `expect.hasAssertions()`',
       suggestAddingHasAssertions: 'Add `expect.hasAssertions()`',
       suggestAddingAssertions:
         'Add `expect.assertions(<number of assertions>)`',
+      suggestReplacingWithAssertions:
+        'Replace with `expect.assertions(<number of assertions>)`',
       suggestRemovingExtraArguments: 'Remove extra arguments',
     },
     type: 'suggestion',
@@ -98,6 +105,11 @@ export default createEslintRule<Options[], MessageIds>({
               'Only check test functions that contain `expect` in callbacks.',
             type: 'boolean',
           },
+          disallowHasAssertions: {
+            description:
+              'Warn when `expect.hasAssertions()` is used instead of `expect.assertions()`.',
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
@@ -107,6 +119,7 @@ export default createEslintRule<Options[], MessageIds>({
         onlyFunctionsWithAsyncKeyword: false,
         onlyFunctionsWithExpectInCallback: false,
         onlyFunctionsWithExpectInLoop: false,
+        disallowHasAssertions: false,
       },
     ],
   },
@@ -152,6 +165,18 @@ export default createEslintRule<Options[], MessageIds>({
             messageId: 'hasAssertionsTakesNoArguments',
             node: expectFnCall.matcher,
             suggest: [suggestRemovingExtraArguments(context, func, 0)],
+          })
+        } else if (options.disallowHasAssertions) {
+          context.report({
+            messageId: 'preferAssertionsOverHasAssertions',
+            node: expectFnCall.matcher,
+            suggest: [
+              {
+                messageId: 'suggestReplacingWithAssertions',
+                fix: (fixer) =>
+                  fixer.replaceText(expectFnCall.members[0], 'assertions'),
+              },
+            ],
           })
         }
         return
@@ -266,8 +291,12 @@ export default createEslintRule<Options[], MessageIds>({
 
         if (secondArg.body.type === AST_NODE_TYPES.BlockStatement) {
           const prefix = testContextName ? `${testContextName}.` : ''
+          if (!options.disallowHasAssertions) {
+            suggestions.push(
+              ['suggestAddingHasAssertions', `${prefix}expect.hasAssertions();`],
+            )
+          }
           suggestions.push(
-            ['suggestAddingHasAssertions', `${prefix}expect.hasAssertions();`],
             ['suggestAddingAssertions', `${prefix}expect.assertions();`],
           )
         }

--- a/tests/prefer-expect-assertions.test.ts
+++ b/tests/prefer-expect-assertions.test.ts
@@ -536,5 +536,64 @@ it('my test description', (context) => {context.expect.assertions();
         },
       ],
     },
+    {
+      code: 'it("it1", function() {expect.hasAssertions();})',
+      options: [{ disallowHasAssertions: true }],
+      errors: [
+        {
+          messageId: 'preferAssertionsOverHasAssertions',
+          column: 30,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestReplacingWithAssertions',
+              output: 'it("it1", function() {expect.assertions();})',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `it('my test description', ({ expect }) => {
+  expect.hasAssertions();
+  const a = 1;
+  expect(a).toBe(1);
+})`,
+      options: [{ disallowHasAssertions: true }],
+      errors: [
+        {
+          messageId: 'preferAssertionsOverHasAssertions',
+          column: 10,
+          line: 2,
+          suggestions: [
+            {
+              messageId: 'suggestReplacingWithAssertions',
+              output: `it('my test description', ({ expect }) => {
+  expect.assertions();
+  const a = 1;
+  expect(a).toBe(1);
+})`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'it("it1", () => {})',
+      options: [{ disallowHasAssertions: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestAddingAssertions',
+              output: 'it("it1", () => {expect.assertions();})',
+            },
+          ],
+        },
+      ],
+    },
   ],
 })


### PR DESCRIPTION
## Summary

Adds a `disallowHasAssertions` option to `vitest/prefer-expect-assertions`.

When enabled, the rule warns on `expect.hasAssertions()` and suggests using `expect.assertions()` instead. Defaults to `false`, so existing behavior is unchanged.

## Motivation

The rule currently accepts both `expect.assertions()` and `expect.hasAssertions()`. Some teams want stricter enforcement by requiring `expect.assertions()` so the expected assertion count is explicit and easier to review.


## Example

```js
// eslint.config.js
{
  rules: {
    'vitest/prefer-expect-assertions': [
      'warn',
      { disallowHasAssertions: true },
    ],
  },
}

// reported when disallowHasAssertions: true
it('example', () => {
  expect.hasAssertions()
  expect(value).toBe(1)
})

// preferred
it('example', () => {
  expect.assertions(1)
  expect(value).toBe(1)
})
```
