### PR TITLE
fix(valid-expect): handle static expect APIs

### DIFF
--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -313,12 +313,13 @@ export default createEslintRule<
           return
         }
 
-        const { parent: expect } = vitestFnCall.head.node
+        const expect = vitestFnCall.expectCall
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) return
+        if (!expect) return
 
         if (expect.arguments.length < minArgs) {
-          const expectLength = getAccessorValue(vitestFnCall.head.node).length
+          const expectLength =
+            expect.callee.loc.end.column - expect.loc.start.column
 
           const loc: TSESTree.SourceLocation = {
             start: {

--- a/src/utils/parse-vitest-fn-call.ts
+++ b/src/utils/parse-vitest-fn-call.ts
@@ -51,11 +51,17 @@ export type KnownMemberExpressionProperty<Specifies extends string = string> =
 interface ModifiersAndMatcher {
   modifiers: KnownMemberExpressionProperty[]
   matcher: KnownMemberExpressionProperty
+  expectCall: TSESTree.CallExpression | null
   /** The arguments that are being passed to the `matcher` */
   args: TSESTree.CallExpression['arguments']
 }
 
-type ExpectChainKind = 'language-chain' | 'modifier' | 'matcher' | 'unknown'
+type ExpectChainKind =
+  | 'expect-api'
+  | 'language-chain'
+  | 'modifier'
+  | 'matcher'
+  | 'unknown'
 
 interface ExpectChain {
   kind: ExpectChainKind
@@ -157,7 +163,8 @@ const hasInvalidExpectChain = (
     modifierChains.some(
       (chain) =>
         chain.kind === 'unknown' ||
-        (chain.kind !== 'matcher' && chain.callExpression),
+        (!['expect-api', 'matcher'].includes(chain.kind) &&
+          chain.callExpression),
     )
   )
     return true
@@ -180,7 +187,9 @@ const hasInvalidExpectChain = (
     .every(
       (chain) =>
         chain.kind !== 'unknown' &&
-        (chain.kind === 'matcher' || !chain.callExpression),
+        (chain.kind === 'expect-api' ||
+          chain.kind === 'matcher' ||
+          !chain.callExpression),
     )
 }
 
@@ -238,6 +247,8 @@ const expectModifiers = new Set<string>([
   ModifierName.resolves,
 ])
 
+const expectApiMethods = new Set(['element', 'poll', 'soft'])
+
 const promiseExpectModifiers = new Set<string>([
   ModifierName.rejects,
   ModifierName.resolves,
@@ -274,6 +285,9 @@ const classifyExpectChain = (
   const callExpression = getCallExpression(member)
 
   if (callExpression) {
+    if (isFirstMemberOfStaticExpectCall && expectApiMethods.has(name))
+      return { kind: 'expect-api', member, callExpression }
+
     // `expect.any(...)` is a static asymmetric matcher factory, not Chai's
     // `.any` flag. Keep uncalled `.any` in Chai chains as a language chain.
     if (isFirstMemberOfStaticExpectCall && name === 'any')
@@ -330,12 +344,19 @@ const parseExpectCallExpression = (
 
   const modifierChains = chains.slice(0, matcherIndex)
   const matcher = chains[matcherIndex]
+  const expectApi = chains.find((chain) => chain.kind === 'expect-api')
 
   return {
     ...typeLessParsedVitestFnCall,
     type: 'expect',
     members: typeLessParsedVitestFnCall.members.slice(0, matcherIndex + 1),
     matcher: matcher.member,
+    expectCall:
+      expectApi?.callExpression ??
+      (typeLessParsedVitestFnCall.head.node.parent?.type ===
+      AST_NODE_TYPES.CallExpression
+        ? typeLessParsedVitestFnCall.head.node.parent
+        : null),
     args: matcher.callExpression?.arguments ?? [],
     modifiers: modifierChains
       .filter((chain) => chain.kind === 'modifier')
@@ -392,6 +413,11 @@ const parseExpectTypeOfCallExpression = (
     ...typeLessParsedVitestFnCall,
     type: 'expectTypeOf',
     matcher,
+    expectCall:
+      typeLessParsedVitestFnCall.head.node.parent?.type ===
+      AST_NODE_TYPES.CallExpression
+        ? typeLessParsedVitestFnCall.head.node.parent
+        : null,
     args: callExpression.arguments,
     modifiers: modifierMembers,
   }

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -23,6 +23,10 @@ ruleTester.run(rule.name, rule, {
     'expect.not.stringMatching(/value/)',
     'expect.not.toBeOneOf([1, 2])',
     'expect.not.toSatisfy(value => value > 0)',
+    'expect.soft("something").toEqual("else");',
+    'expect.soft("something").not.toEqual("else");',
+    'expect.poll(() => "something").toEqual("else");',
+    'expect.element(element).toBeInTheDocument();',
     'expect("something").toEqual("else");',
     'expect(true).toBeDefined();',
     'expect([1, 2, 3]).toEqual([1, 2, 3]);',
@@ -314,6 +318,20 @@ ruleTester.run(rule.name, rule, {
       ],
     },
     {
+      code: 'expect.soft().toBe(2);',
+      errors: [
+        {
+          endColumn: 13,
+          column: 12,
+          messageId: 'notEnoughArgs',
+        },
+      ],
+    },
+    {
+      code: 'expect.soft(1, 2).toBe(2);',
+      errors: [{ messageId: 'tooManyArgs' }],
+    },
+    {
       code: 'expect().toBe(true);',
       errors: [
         {
@@ -473,6 +491,18 @@ ruleTester.run(rule.name, rule, {
     {
       code: 'expect("something");',
       errors: [{ endColumn: 20, column: 1, messageId: 'matcherNotFound' }],
+    },
+    {
+      code: 'expect.soft("something");',
+      errors: [{ endColumn: 25, column: 1, messageId: 'matcherNotFound' }],
+    },
+    {
+      code: 'expect.poll(() => value);',
+      errors: [{ messageId: 'matcherNotFound' }],
+    },
+    {
+      code: 'expect.element(element);',
+      errors: [{ messageId: 'matcherNotFound' }],
     },
     {
       code: 'expect();',


### PR DESCRIPTION
## Summary

- classify `expect.soft`, `expect.poll`, and `expect.element` as expect APIs instead of matchers
- validate their actual matcher chains and argument counts through the existing `valid-expect` logic
- add coverage for valid chains, missing matchers, modifiers, and argument-count diagnostics

## Validation

- `corepack pnpm test --run` — 82 files, 2,357 tests passed
- `corepack pnpm typecheck`
- `corepack pnpm lint:js`
- `corepack pnpm format`
- `corepack pnpm build`

Local validation used Node.js 20.20.0; the repository CI matrix will additionally exercise Node.js 22 and 24 on Ubuntu and Windows.

Fixes #921
Fixes #922
