### PR TITLE
fix(valid-expect): support expect.assert members

### DIFF
--- a/src/utils/parse-vitest-fn-call.ts
+++ b/src/utils/parse-vitest-fn-call.ts
@@ -308,6 +308,9 @@ const classifyExpectChain = (
     return { kind: 'matcher', member, callExpression }
   }
 
+  if (isFirstMemberOfStaticExpectCall && name === 'assert')
+    return { kind: 'expect-api', member, callExpression }
+
   if (chaiChainableProperties.has(name))
     return { kind: 'language-chain', member, callExpression }
 

--- a/tests/valid-expect.test.ts
+++ b/tests/valid-expect.test.ts
@@ -5,6 +5,9 @@ ruleTester.run(rule.name, rule, {
   valid: [
     'expect.hasAssertions',
     'expect.hasAssertions()',
+    'expect.assert(value)',
+    'expect.assert.isDefined(value)',
+    'expect.assert.exists(value)',
     'expect.any(String)',
     'expect.anything()',
     'expect.arrayContaining([1])',


### PR DESCRIPTION
Fixes #935

## Changes
- Treat `expect.assert` as a static namespace when followed by Chai assert methods.
- Add regression coverage for `expect.assert.isDefined()` and `expect.assert.exists()` while preserving bare `expect.assert()`.

## Validation
- `pnpm exec vitest run tests/valid-expect.test.ts` (193 passed)
- Full suite: 2363 passed; 3 Windows parallel timeout cases passed separately with `--maxWorkers=1` (359 passed)
- `pnpm typecheck`
- `pnpm build`
- ESLint and Prettier on changed files

AI-assisted: Codex was used to implement and validate this change.