### PR TITLE
fix: detect test modes in options objects

### DIFF
--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -1,4 +1,8 @@
-import { createEslintRule, getAccessorValue } from '../utils'
+import {
+  createEslintRule,
+  findVitestModeProperty,
+  getAccessorValue,
+} from '../utils'
 import { parseVitestFnCall, resolveScope } from '../utils/parse-vitest-fn-call'
 import { getScope } from '../utils/scope'
 
@@ -61,13 +65,19 @@ export default createEslintRule<Options, MESSAGE_ID>({
         const skipMember = vitestFnCall.members.find(
           (s) => getAccessorValue(s) === 'skip',
         )
-        if (vitestFnCall.name.startsWith('x') || skipMember !== undefined) {
+        const skipProperty =
+          vitestFnCall.type === 'describe' || vitestFnCall.type === 'test'
+            ? findVitestModeProperty(node, 'skip')
+            : null
+        const skipNode = skipMember ?? skipProperty?.key
+
+        if (vitestFnCall.name.startsWith('x') || skipNode) {
           context.report({
             messageId:
               vitestFnCall.type === 'describe'
                 ? 'disabledSuite'
                 : 'disabledTest',
-            node: skipMember ?? vitestFnCall.head.node,
+            node: skipNode ?? vitestFnCall.head.node,
           })
         }
       },

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -1,4 +1,8 @@
-import { createEslintRule, getAccessorValue } from '../utils'
+import {
+  createEslintRule,
+  findVitestModeProperty,
+  getAccessorValue,
+} from '../utils'
 import { parseVitestFnCall } from '../utils/parse-vitest-fn-call'
 
 export type MessageIds = 'noFocusedTests'
@@ -54,14 +58,27 @@ export default createEslintRule<Options, MessageIds>({
           (m) => getAccessorValue(m) === 'only',
         )
 
-        if (isTestOrDescribe && onlyNode) {
+        const onlyProperty = findVitestModeProperty(node, 'only')
+        const focusedNode = onlyNode ?? onlyProperty?.key
+
+        if (isTestOrDescribe && focusedNode) {
           context.report({
-            node: onlyNode,
+            node: focusedNode,
             messageId: 'noFocusedTests',
-            fix: (fixer) =>
-              fixable
-                ? fixer.removeRange([onlyNode.range[0] - 1, onlyNode.range[1]])
-                : null,
+            fix: (fixer) => {
+              if (!fixable) return null
+
+              if (onlyNode)
+                return fixer.removeRange([
+                  onlyNode.range[0] - 1,
+                  onlyNode.range[1],
+                ])
+
+              if (onlyProperty)
+                return fixer.replaceText(onlyProperty.value, 'false')
+
+              return null
+            },
           })
         }
       },

--- a/src/rules/warn-todo.ts
+++ b/src/rules/warn-todo.ts
@@ -1,4 +1,4 @@
-import { createEslintRule } from '../utils'
+import { createEslintRule, findVitestModeProperty } from '../utils'
 import { parseVitestFnCall } from '../utils/parse-vitest-fn-call'
 
 const RULE_NAME = 'warn-todo'
@@ -32,11 +32,14 @@ export default createEslintRule({
           (m) => m.type === 'Identifier' && m.name === 'todo',
         )
 
-        if (!todoMember) return
+        const todoProperty = findVitestModeProperty(node, 'todo')
+        const todoNode = todoMember ?? todoProperty?.key
+
+        if (!todoNode) return
 
         context.report({
           messageId: 'warnTodo',
-          node: todoMember,
+          node: todoNode,
         })
       },
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -147,6 +147,29 @@ export const getAccessorValue = <S extends string = string>(
     ? accessor.name
     : getStringValue(accessor)
 
+export const findVitestModeProperty = (
+  node: TSESTree.CallExpression,
+  mode: 'only' | 'skip' | 'todo',
+): TSESTree.Property | null => {
+  const options = node.arguments[1]
+
+  if (options?.type !== AST_NODE_TYPES.ObjectExpression) return null
+
+  const property = options.properties.findLast(
+    (property): property is TSESTree.Property =>
+      property.type === AST_NODE_TYPES.Property &&
+      isSupportedAccessor(property.key, mode),
+  )
+
+  if (
+    property?.value.type !== AST_NODE_TYPES.Literal ||
+    property.value.value !== true
+  )
+    return null
+
+  return property
+}
+
 /**
  * Gets the value of the given `StringNode`.
  *

--- a/tests/no-disabled-tests.test.ts
+++ b/tests/no-disabled-tests.test.ts
@@ -10,6 +10,7 @@ ruleTester.run(rule.name, rule, {
     'it.each("foo", () => {})',
     'it.concurrent("foo", function () {})',
     'test("foo", function () {})',
+    'test("foo", { skip: false }, function () {})',
     'test.only("foo", function () {})',
     'test.concurrent("foo", function () {})',
     'describe[`${"skip"}`]("foo", function () {})',
@@ -50,6 +51,30 @@ ruleTester.run(rule.name, rule, {
           endLine: 1,
           line: 1,
           messageId: 'disabledSuite',
+        },
+      ],
+    },
+    {
+      code: 'describe("foo", { skip: true }, function () {})',
+      errors: [
+        {
+          column: 19,
+          endColumn: 23,
+          endLine: 1,
+          line: 1,
+          messageId: 'disabledSuite',
+        },
+      ],
+    },
+    {
+      code: 'test("foo", { skip: true }, function () {})',
+      errors: [
+        {
+          column: 15,
+          endColumn: 19,
+          endLine: 1,
+          line: 1,
+          messageId: 'disabledTest',
         },
       ],
     },

--- a/tests/no-focused-tests.test.ts
+++ b/tests/no-focused-tests.test.ts
@@ -8,6 +8,7 @@ ruleTester.run(rule.name, rule, {
     'it.for([])("test", () => {});',
 
     'test("test", () => {});',
+    'test("test", { only: false }, () => {});',
     'test.each([])("test", () => {});',
     'test.for([])("test", () => {});',
 
@@ -78,6 +79,23 @@ ruleTester.run(rule.name, rule, {
         {
           column: 4,
           endColumn: 8,
+          endLine: 1,
+          line: 1,
+          messageId: 'noFocusedTests',
+        },
+      ],
+    },
+    {
+      options: [
+        {
+          fixable: false,
+        },
+      ],
+      code: 'test("test", { only: true }, () => {});',
+      errors: [
+        {
+          column: 16,
+          endColumn: 20,
           endLine: 1,
           line: 1,
           messageId: 'noFocusedTests',
@@ -213,6 +231,19 @@ ruleTester.run(rule.name, rule, {
         },
       ],
       output: 'test("test", () => {});',
+    },
+    {
+      code: 'test("test", { only: true }, () => {});',
+      errors: [
+        {
+          column: 16,
+          endColumn: 20,
+          endLine: 1,
+          line: 1,
+          messageId: 'noFocusedTests',
+        },
+      ],
+      output: 'test("test", { only: false }, () => {});',
     },
     {
       code: 'it.only.each([])("test", () => {});',

--- a/tests/warn-todo.test.ts
+++ b/tests/warn-todo.test.ts
@@ -7,6 +7,7 @@ ruleTester.run(rule.name, rule, {
     'it("foo", function () {})',
     'it.concurrent("foo", function () {})',
     'test("foo", function () {})',
+    'test("foo", { todo: false }, function () {})',
     'test.concurrent("foo", function () {})',
     'describe.only("foo", function () {})',
     'it.only("foo", function () {})',
@@ -24,6 +25,10 @@ ruleTester.run(rule.name, rule, {
     {
       code: 'test.todo("foo", function () {})',
       errors: [{ messageId: 'warnTodo', column: 6, line: 1 }],
+    },
+    {
+      code: 'test("foo", { todo: true }, function () {})',
+      errors: [{ messageId: 'warnTodo', column: 15, line: 1 }],
     },
     {
       code: 'describe.todo.each([])("foo", function () {})',


### PR DESCRIPTION
Fixes #897

Adds support for `only`, `skip`, and `todo` when they are enabled through a test options object. Only literal `true` values are treated as active, and the existing autofixes continue to work for focused and disabled tests.

Tests cover all three rules, autofixes, and false-value cases.