### PR TITLE
docs(valid-title): fixed the description of the valid-title option

### DIFF
--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -95,9 +95,9 @@ Examples of **incorrect** code for this rule with the `{ "disallowedWords": ["Ba
 
 ```js
 describe('foo', () => {
-  it("Includes ng keyword Bar", () => {
-    expect(1).toBe(1);
-  });
+  it('Includes ng keyword Bar', () => {
+    expect(1).toBe(1)
+  })
 })
 ```
 

--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -69,6 +69,8 @@ describe('1', () => {
 
 If `true`, the rule ignores the arguments of the `describe`, `test`, and `it` functions.
 
+However, function calls and property accesses are not included in this skip and are detected as errors.
+
 Examples of **correct** code for this rule with the `{ "allowArguments": false }` option:
 
 ```js
@@ -89,21 +91,21 @@ describe(foo, () => {
 
 An array of words that are not allowed in the test title.
 
-Examples of **incorrect** code for this rule with the `{ "disallowedWords": ["skip", "only"] }` option:
+Examples of **incorrect** code for this rule with the `{ "disallowedWords": ["Bar"] }` option:
 
 ```js
 describe('foo', () => {
-  it.skip('should be skipped', () => {
-    expect(1).toBe(1)
-  })
+  it("Includes ng keyword Bar", () => {
+    expect(1).toBe(1);
+  });
 })
 ```
 
-Examples of **correct** code for this rule with the `{ "disallowedWords": ["skip", "only"] }` option:
+Examples of **correct** code for this rule with the `{ "disallowedWords": ["Bar"] }` option:
 
 ```js
 describe('foo', () => {
-  it('should be skipped', () => {
+  it('Not includes ng keyword', () => {
     expect(1).toBe(1)
   })
 })


### PR DESCRIPTION
Regarding option `allowArguments` and `disallowedWords`.

# allowArguments

I added a note explaining that `getTitle()` or `obj.title` will still result in an error, even with `allowArguments: true`.

In other words: 

```js
// OK
describe(foo, () => {
  it(foo, () => {
    expect(1).toBe(1)
  })
})

// NG
it(getTitle(), () => {
  expect(1).toBe(1)
})

// NG
it(obj.title, () => {
  expect(1).toBe(1)
})
```

# disallowedWords

I verified the behavior, and the samples marked as "incorrect" in the documentation actually pass the check.

<img width="447" height="235" alt="image" src="https://github.com/user-attachments/assets/a4095c44-48c9-4e74-ba82-0769e4ec9fb1" />

Also, looking into the implementation, it simply validates keywords against the title string using regular expressions, so having a sample case like `it.skip` only causes confusion.

I simplified the implementation example to only check whether it contains NG keywords or not.