### PR TITLE
fix(valid-title): Refine the reportEmptyTitle message

### DIFF
--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -239,7 +239,9 @@ export default createEslintRule<Options, MESSAGE_IDS>({
               functionName:
                 vitestFnCall.type === 'describe'
                   ? DescribeAlias.describe
-                  : TestCaseName.test,
+                  : vitestFnCall.type === 'test'
+                    ? TestCaseName.test
+                    : TestCaseName.it,
             },
             node,
           })

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -239,9 +239,9 @@ export default createEslintRule<Options, MESSAGE_IDS>({
               functionName:
                 vitestFnCall.type === 'describe'
                   ? DescribeAlias.describe
-                  : vitestFnCall.type === 'test'
-                    ? TestCaseName.test
-                    : TestCaseName.it,
+                  : trimFXPrefix(vitestFnCall.name) === TestCaseName.it
+                    ? TestCaseName.it
+                    : TestCaseName.test,
             },
             node,
           })

--- a/tests/valid-title.test.ts
+++ b/tests/valid-title.test.ts
@@ -607,6 +607,21 @@ ruleTester.run(rule.name, rule, {
           messageId: 'emptyTitle',
           column: 7,
           line: 3,
+          data: { functionName: 'it' },
+        },
+      ],
+    },
+    {
+      code: `
+       describe('foo', () => {
+      test('', () => {});
+       });
+     `,
+      errors: [
+        {
+          messageId: 'emptyTitle',
+          column: 7,
+          line: 3,
           data: { functionName: 'test' },
         },
       ],
@@ -618,7 +633,7 @@ ruleTester.run(rule.name, rule, {
           messageId: 'emptyTitle',
           column: 1,
           line: 1,
-          data: { functionName: 'test' },
+          data: { functionName: 'it' },
         },
       ],
     },
@@ -630,7 +645,7 @@ ruleTester.run(rule.name, rule, {
           messageId: 'emptyTitle',
           column: 1,
           line: 1,
-          data: { functionName: 'test' },
+          data: { functionName: 'it' },
         },
       ],
     },
@@ -641,7 +656,7 @@ ruleTester.run(rule.name, rule, {
           messageId: 'emptyTitle',
           column: 1,
           line: 1,
-          data: { functionName: 'test' },
+          data: { functionName: 'it' },
         },
       ],
     },


### PR DESCRIPTION
In the follwing case:

```ts
import { describe, it, expect } from "vitest";

describe("", () => {
    test("", () => {
        expect(1).toBe(1);
    });
    it("", () => {
        expect(1).toBe(1);
    });
});
```

report messages are:

```
  3:1  error  describe should not have an empty title  vitest/valid-title
  4:5  error  test should not have an empty title      vitest/valid-title
  7:5  error  test should not have an empty title      vitest/valid-title
```

In this particular instance, the situation is straightforward, but because the output showed `test` even though I had written `it`, I spent time searching for a `test` function that didn't actually exist on that line. 

Given that the implementation branches between `describe` and `test`, I believe it would be more user-friendly to explicitly specify `it`. Alternatively, if using `it` is considered confusing, I think it should be written like this:

```
// add `()`
emptyTitle: '{{ functionName }}() should not have an empty title',
```

and it will be:

```
  3:1  error  describe() should not have an empty title  vitest/valid-title
  4:5  error  test() should not have an empty title      vitest/valid-title
  7:5  error  it() should not have an empty title      vitest/valid-title
```