### PR TITLE
fix(valid-title): handle missing argument in valid-title rule

### DIFF
--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -246,6 +246,9 @@ export default createEslintRule<Options, MESSAGE_IDS>({
         }
 
         const [argument] = node.arguments
+        if (!argument) {
+          return
+        }
 
         const getArgumentType = () => {
           if (!settings.typecheck) return null
@@ -257,10 +260,7 @@ export default createEslintRule<Options, MESSAGE_IDS>({
         const type = getArgumentType()
         if (type && isClassOrFunctionType(type)) return
 
-        if (
-          !argument ||
-          (allowArguments && argument.type === AST_NODE_TYPES.Identifier)
-        )
+        if (allowArguments && argument.type === AST_NODE_TYPES.Identifier)
           return
 
         if (!isStringNode(argument)) {


### PR DESCRIPTION
If there is no `argument`, performing an early return is more performant.
There is no need to unnecessarily execute:

- `getArgumentType()`
- `services.getTypeAtLocation(argument)`
- `if (type && isClassOrFunctionType(type)) return`