### PR TITLE
chore: install pinact for static analysis

### DIFF
--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,0 +1,27 @@
+name: pinact
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    name: Check GitHub Actions are pinned to SHA
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          skip_push: 'true'
+          fix: 'false'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
In this project's GitHub Actions, SHAs are pinned. However, the practice of pinning SHAs itself is not enforced via mechanisms such as static analysis. Since there is a possibility that notations like `v7` could be introduced in the future, I propose using `pinact` for static analysis.

FYI: https://github.com/suzuki-shunsuke/pinact