### PR TITLE
chore: update node engine requirement to >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
node 18 has been already EOL, and This repository ci node version targets are 22 and 24.

Thus I believe `engines` target should be directed 22 which is now oldest LTS version.

FYI: https://nodejs.org/en/about/previous-releases