### PR TITLE
chore: update pnpm version to 11.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       "optional": true
     }
   },
-  "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",
+  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
   "engines": {
     "node": ">=18"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
+allowBuilds:
+  esbuild: true
+
 injectWorkspacePackages: true
 
-onlyBuiltDependencies:
-  - esbuild
+minimumReleaseAge: 10080 # 7 days
 
 savePrefix: ^


### PR DESCRIPTION
And I added [minimumReleaseAge](https://pnpm.io/ja/settings/dependency-resolution#minimumreleaseage) option to protect from suply-chain attack.

By configuring this option, only libraries for which a certain period has elapsed since their release can be installed.