### PR TITLE
bugfix(consistent-test-it): fixed a bug where aliases were also deleted during the fix operation

### DIFF
--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -109,6 +109,16 @@ export default createEslintRule<
             data: { testFnKeyWork, oppositeTestKeyword },
             messageId: 'consistentMethod',
             fix: (fixer) => {
+              const isAliased = specifier.local.name !== oppositeTestKeyword
+
+              const preferredLocalName = isAliased
+                ? specifier.local.name
+                : testFnDisabled
+              const preferredSpecifierText =
+                preferredLocalName === testFnDisabled
+                  ? testFnDisabled
+                  : `${testFnDisabled} as ${preferredLocalName}`
+
               const remainingSpecifiers = node.specifiers.filter(
                 (spec) => spec !== specifier,
               )
@@ -117,13 +127,14 @@ export default createEslintRule<
                   (spec) =>
                     spec.type === AST_NODE_TYPES.ImportSpecifier &&
                     spec.imported.type === AST_NODE_TYPES.Identifier &&
-                    spec.imported.name === testFnDisabled,
+                    spec.imported.name === testFnDisabled &&
+                    spec.local.name === preferredLocalName,
                 )
                 const importNames = remainingSpecifiers.map((spec) =>
                   sourceCode.getText(spec),
                 )
                 if (!hasPreferredSpecifier) {
-                  importNames.push(testFnDisabled)
+                  importNames.push(preferredSpecifierText)
                 }
 
                 const importText = importNames.join(', ')
@@ -136,7 +147,7 @@ export default createEslintRule<
                 )
               }
 
-              return fixer.replaceText(specifier, testFnDisabled)
+              return fixer.replaceText(specifier, preferredSpecifierText)
             },
           })
         }
@@ -162,6 +173,15 @@ export default createEslintRule<
             : node.callee.type === AST_NODE_TYPES.CallExpression
               ? node.callee.callee
               : node.callee
+
+        const renameTarget =
+          funcNode.type === AST_NODE_TYPES.MemberExpression
+            ? funcNode.object
+            : funcNode
+        const isAliasedCall =
+          renameTarget.type === AST_NODE_TYPES.Identifier &&
+          renameTarget.name !== vitestFnCall.name
+
         if (
           vitestFnCall.type === 'test' &&
           describeNestingLevel === 0 &&
@@ -173,7 +193,9 @@ export default createEslintRule<
             node: node.callee,
             data: { testFnKeyWork, oppositeTestKeyword },
             messageId: 'consistentMethod',
-            fix: buildFixer(funcNode, vitestFnCall.name, testFnKeyWork),
+            fix: isAliasedCall
+              ? null
+              : buildFixer(funcNode, vitestFnCall.name, testFnKeyWork),
           })
         } else if (
           vitestFnCall.type === 'test' &&
@@ -188,11 +210,13 @@ export default createEslintRule<
             messageId: 'consistentMethodWithinDescribe',
             node: node.callee,
             data: { testKeywordWithinDescribe, oppositeTestKeyword },
-            fix: buildFixer(
-              funcNode,
-              vitestFnCall.name,
-              testKeywordWithinDescribe,
-            ),
+            fix: isAliasedCall
+              ? null
+              : buildFixer(
+                  funcNode,
+                  vitestFnCall.name,
+                  testKeywordWithinDescribe,
+                ),
           })
         }
       },

--- a/tests/consistent-test-it.test.ts
+++ b/tests/consistent-test-it.test.ts
@@ -340,7 +340,9 @@ ruleTester.run(rule.name, rule, {
     },
     {
       code: 'import { it as baseIt, test } from "vitest"\nbaseIt("foo")',
-      output: 'import { it as baseIt } from "vitest"\nbaseIt("foo")',
+      // `it as baseIt` does not provide an `it` binding, so the replacement
+      // specifier must still be added for renamed `test` call sites.
+      output: 'import { it as baseIt, it } from "vitest"\nbaseIt("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {
@@ -352,6 +354,119 @@ ruleTester.run(rule.name, rule, {
           column: 24,
           endColumn: 28,
           line: 1,
+        },
+      ],
+    },
+    {
+      // The local alias must be preserved so the call site keeps resolving.
+      code: 'import { test as t } from "vitest"\nt("foo")',
+      output: 'import { it as t } from "vitest"\nt("foo")',
+      options: [{ fn: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+          line: 1,
+          column: 10,
+          endColumn: 19,
+        },
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+          line: 2,
+          column: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      // An existing `it` binding must not swallow the aliased specifier.
+      code: 'import { test as t, it } from "vitest"\nt("foo")\nit("bar")',
+      output: 'import { it, it as t } from "vitest"\nt("foo")\nit("bar")',
+      options: [{ fn: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+          line: 1,
+          column: 10,
+          endColumn: 19,
+        },
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+          line: 2,
+          column: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      // `.each` tagged templates go through the same aliased-callee guard.
+      code: 'import { test as t } from "vitest"\nt.each`a`("foo", () => {})',
+      output: 'import { it as t } from "vitest"\nt.each`a`("foo", () => {})',
+      options: [{ fn: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+          line: 1,
+          column: 10,
+          endColumn: 19,
+        },
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+          line: 2,
+          column: 1,
+          endColumn: 10,
+        },
+      ],
+    },
+    {
+      // The alias already matches the preferred name, so no `as` is needed.
+      code: 'import { it as test } from "vitest"\ntest("foo")',
+      output: 'import { test } from "vitest"\ntest("foo")',
+      options: [{ fn: TestCaseName.test }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it,
+          },
+          line: 1,
+          column: 10,
+          endColumn: 20,
+        },
+        {
+          // Reported but not fixed; the import fix alone resolves it.
+          messageId: 'consistentMethod',
+          data: {
+            testFnKeyWork: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it,
+          },
+          line: 2,
+          column: 1,
+          endColumn: 5,
         },
       ],
     },


### PR DESCRIPTION
When declared `test` with `as`

```ts
import { expect, test as t } from "vitest";

const runner = t;

t("via alias", () => {
    expect(runner).toBeTypeOf("function");
});
```

Running `fix` removes the `as`, resulting in an error: 

```ts
import { expect, it } from "vitest";

// error  't' is not defined 
const runner = t;

t("via alias", () => {
    expect(runner).toBeTypeOf("function");
});
```

I modified it so that 'as' remains.