### PR TITLE
fix(prefer-describe-function-title): ignore type-only imports

### DIFF
--- a/src/rules/prefer-describe-function-title.ts
+++ b/src/rules/prefer-describe-function-title.ts
@@ -1,5 +1,8 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils'
-import { DefinitionType } from '@typescript-eslint/scope-manager'
+import {
+  DefinitionType,
+  type Definition,
+} from '@typescript-eslint/scope-manager'
 import { createEslintRule } from '../utils'
 import { parsePluginSettings } from '../utils/parse-plugin-settings'
 import { parseVitestFnCall } from '../utils/parse-vitest-fn-call'
@@ -9,6 +12,24 @@ import { isClassOrFunctionType } from '../utils/types'
 const RULE_NAME = 'prefer-describe-function-title'
 export type MESSAGE_IDS = 'preferFunction'
 export type Options = []
+
+/**
+ * Is this import binding type-only (`import type { x }` / `import { type x }`)?
+ *
+ * Such a binding is erased at compile time, so the identifier does not exist as a
+ * value at runtime and cannot be passed to `describe`.
+ */
+function isTypeOnlyImport(definition: Definition): boolean {
+  if (definition.type !== DefinitionType.ImportBinding) {
+    return false
+  }
+
+  return (
+    definition.parent.importKind === 'type' ||
+    (definition.node.type === AST_NODE_TYPES.ImportSpecifier &&
+      definition.node.importKind === 'type')
+  )
+}
 
 export default createEslintRule<Options, MESSAGE_IDS>({
   name: RULE_NAME,
@@ -43,7 +64,8 @@ export default createEslintRule<Options, MESSAGE_IDS>({
           const scopedFunction = scope?.set.get(identifierName)?.defs[0]
           if (
             scopedFunction?.type !== DefinitionType.ImportBinding ||
-            argument.property.name !== 'name'
+            argument.property.name !== 'name' ||
+            isTypeOnlyImport(scopedFunction)
           ) {
             return
           }
@@ -76,7 +98,10 @@ export default createEslintRule<Options, MESSAGE_IDS>({
         }
 
         const scopedFunction = scope?.set.get(describedTitle)?.defs[0]
-        if (scopedFunction?.type !== DefinitionType.ImportBinding) {
+        if (
+          scopedFunction?.type !== DefinitionType.ImportBinding ||
+          isTypeOnlyImport(scopedFunction)
+        ) {
           return
         }
 

--- a/tests/prefer-describe-function-title.test.ts
+++ b/tests/prefer-describe-function-title.test.ts
@@ -113,6 +113,29 @@ ruleTester.run(rule.name, rule, {
         },
       },
     },
+    // Type-only imports are erased at runtime, so the identifier cannot be used
+    // as a value: the "fix" would not compile.
+    {
+      code: `
+        import type { myFunction } from "./myFunction"
+        describe("myFunction", () => {})
+      `,
+      filename: 'myFunction.test.ts',
+    },
+    {
+      code: `
+        import { type myFunction } from "./myFunction"
+        describe("myFunction", () => {})
+      `,
+      filename: 'myFunction.test.ts',
+    },
+    {
+      code: `
+        import type myFunction from "./myFunction"
+        describe("myFunction", () => {})
+      `,
+      filename: 'myFunction.test.ts',
+    },
   ],
   invalid: [
     {

--- a/tests/prefer-describe-function-title.test.ts
+++ b/tests/prefer-describe-function-title.test.ts
@@ -136,6 +136,20 @@ ruleTester.run(rule.name, rule, {
       `,
       filename: 'myFunction.test.ts',
     },
+    {
+      code: `
+        import type * as myFunction from "./myFunction"
+        describe("myFunction", () => {})
+      `,
+      filename: 'myFunction.test.ts',
+    },
+    {
+      code: `
+        import type * as myFunction from "./myFunction"
+        describe(myFunction.name, () => {})
+      `,
+      filename: 'myFunction.test.ts',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #954.

## Problem

A type-only import is erased at compile time, so the identifier does not exist as a value at runtime:

```ts
import type { myFunction } from "./myFunction"

describe("myFunction", () => {}) // reported
```

The rule reports the string title and autofixes it to `describe(myFunction, ...)`, which does not compile — `myFunction` is a type, not a value. Since the rule is fixable, `--fix` silently breaks the file.

The check only asked whether the binding was a `DefinitionType.ImportBinding`, which is true for type-only imports as well.

## Fix

Skip bindings whose import is type-only, covering both syntaxes:

```ts
function isTypeOnlyImport(definition: Definition): boolean {
  if (definition.type !== DefinitionType.ImportBinding) return false
  return (
    definition.parent.importKind === "type" ||            // import type { x } / import type x
    (definition.node.type === AST_NODE_TYPES.ImportSpecifier &&
      definition.node.importKind === "type")              // import { type x }
  )
}
```

Applied to both report paths — the string-literal title and the `myFunction.name` member form, which has the same problem.

Value imports are untouched, so every existing invalid case still reports and fixes as before.

## Tests

Three valid cases added, one per syntax (`import type { x }`, `import { type x }`, `import type x`). All three fail on `main` and pass with the fix.

## Validation

- `vitest run` → **2378 passed** (82 files)
- `tsc --noEmit` → clean
- `eslint` → clean
- `prettier --check` → clean