### PR TITLE
fix(consistent-test-it): check the written name, not the resolved one

### DIFF
--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -39,6 +39,33 @@ function getOppositeTestKeyword(test: TestCaseName.test | TestCaseName.it) {
   return TestCaseName.test
 }
 
+/**
+ * `parseVitestFnCall` reports the name the call *resolves* to, which is not
+ * always the name that is written in the source: a binding created with
+ * `test.extend()` resolves back to `test`, and an aliased import resolves back
+ * to what it imports.
+ *
+ * This rule is about how the call is *spelled*, so a local name that is itself
+ * a test keyword is what should be checked — `it(...)` already uses `it`, no
+ * matter what it resolves to.
+ */
+const getWrittenName = (vitestFnCall: {
+  name: string
+  head: { local: string }
+}) =>
+  Object.hasOwn(TestCaseName, vitestFnCall.head.local)
+    ? vitestFnCall.head.local
+    : vitestFnCall.name
+
+/**
+ * The fixer rewrites the callee in place, which is only safe when the call
+ * goes straight to the vitest export. Renaming an alias or a binding created
+ * with `test.extend()` would point the call at a different function (or at no
+ * binding at all), so those are reported without a fix.
+ */
+const isRenamable = (vitestFnCall: { name: string; head: { local: string } }) =>
+  vitestFnCall.name === vitestFnCall.head.local
+
 export default createEslintRule<
   [
     Partial<{
@@ -162,10 +189,13 @@ export default createEslintRule<
             : node.callee.type === AST_NODE_TYPES.CallExpression
               ? node.callee.callee
               : node.callee
+        const writtenName = getWrittenName(vitestFnCall)
+        const renamable = isRenamable(vitestFnCall)
+
         if (
           vitestFnCall.type === 'test' &&
           describeNestingLevel === 0 &&
-          !vitestFnCall.name.endsWith(testFnKeyWork)
+          !writtenName.endsWith(testFnKeyWork)
         ) {
           const oppositeTestKeyword = getOppositeTestKeyword(testFnKeyWork)
 
@@ -173,12 +203,14 @@ export default createEslintRule<
             node: node.callee,
             data: { testFnKeyWork, oppositeTestKeyword },
             messageId: 'consistentMethod',
-            fix: buildFixer(funcNode, vitestFnCall.name, testFnKeyWork),
+            fix: renamable
+              ? buildFixer(funcNode, writtenName, testFnKeyWork)
+              : undefined,
           })
         } else if (
           vitestFnCall.type === 'test' &&
           describeNestingLevel > 0 &&
-          !vitestFnCall.name.endsWith(testKeywordWithinDescribe)
+          !writtenName.endsWith(testKeywordWithinDescribe)
         ) {
           const oppositeTestKeyword = getOppositeTestKeyword(
             testKeywordWithinDescribe,
@@ -188,11 +220,9 @@ export default createEslintRule<
             messageId: 'consistentMethodWithinDescribe',
             node: node.callee,
             data: { testKeywordWithinDescribe, oppositeTestKeyword },
-            fix: buildFixer(
-              funcNode,
-              vitestFnCall.name,
-              testKeywordWithinDescribe,
-            ),
+            fix: renamable
+              ? buildFixer(funcNode, writtenName, testKeywordWithinDescribe)
+              : undefined,
           })
         }
       },

--- a/tests/consistent-test-it.test.ts
+++ b/tests/consistent-test-it.test.ts
@@ -151,6 +151,19 @@ ruleTester.run(rule.name, rule, {
       code: 'describe("suite", () => { test("foo") })',
       options: [{ fn: TestCaseName.test }],
     },
+    // https://github.com/vitest-dev/eslint-plugin-vitest/issues/956
+    {
+      code: `import { describe, test } from 'vitest';
+const it = test.extend({});
+describe("suite", () => { it("foo") })`,
+      options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
+    },
+    {
+      code: `import { describe, it } from 'vitest';
+const test = it.extend({});
+describe("suite", () => { test("foo") })`,
+      options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
+    },
   ],
   invalid: [
     {
@@ -158,6 +171,25 @@ ruleTester.run(rule.name, rule, {
       options: [{ fn: TestCaseName.test }],
       output: 'test("shows error", () => {});',
       errors: [{ messageId: 'consistentMethod' }],
+    },
+    // https://github.com/vitest-dev/eslint-plugin-vitest/issues/956
+    // still reported, but not auto-fixed: `it` is the extended binding, so
+    // rewriting it to `test` would call a different function.
+    {
+      code: `import { test } from 'vitest';
+const it = test.extend({});
+it("foo")`,
+      options: [{ fn: TestCaseName.test }],
+      output: null,
+      errors: [{ messageId: 'consistentMethod' }],
+    },
+    {
+      code: `import { describe, test } from 'vitest';
+const myTest = test.extend({});
+describe("suite", () => { myTest("foo") })`,
+      options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
+      output: null,
+      errors: [{ messageId: 'consistentMethodWithinDescribe' }],
     },
     {
       code: 'describe("suite", () => { it("foo") })',


### PR DESCRIPTION
Closes #956

### Problem

With the standard fixture idiom, the extended binding is spelled `it`:

```js
import { describe, expect, test } from 'vitest'

const it = test.extend({ fixture: async ({}, use) => use('hello') })

describe('example', () => {
  it('uses the fixture', ({ fixture }) => {
    expect(fixture).toBe('hello')
  })
})
```

Every `it(...)` inside the `describe` is reported with *"Prefer using it instead of test within describe"*, and the autofix rewrites `it` to `it` — so `--fix` never converges and ESLint keeps counting these as fixable problems.

This is distinct from #884, which is about the report on the `.extend()` factory call itself; skipping factory calls leaves this case in place.

### Cause

`parseVitestFnCall` returns `name = resolved.original ?? resolved.local`, and `resolveScope` follows `const it = test.extend(...)` back to the `test` import — so the resolved name is `test` for every call through the binding. The rule then tests that resolved name:

```ts
!vitestFnCall.name.endsWith(testKeywordWithinDescribe)
```

Since a single resolved name is shared by the top-level and describe-nested calls, no import origin can satisfy both halves of the rule.

### Fix

The rule is about how a call is *spelled*, so it now checks the local name when that name is itself a test-case keyword, falling back to the resolved name otherwise (`getWrittenName`). `it(...)` is therefore treated as `it`, whatever it resolves to.

The fixer rewrites the callee in place, which is only sound when the call goes straight to the vitest export. Renaming an alias or an `extend()` binding would point the call at a *different* function, so when the local and resolved names differ the report is emitted without a fix (`isRenamable`) — the user still gets the diagnostic, but `--fix` cannot silently break their fixtures.

### Tests

Added to `tests/consistent-test-it.test.ts`:

- valid — `const it = test.extend({})` used inside `describe` with `withinDescribe: 'it'` (the reported case), plus the mirrored `const test = it.extend({})` with `withinDescribe: 'test'`.
- invalid — the same bindings used where they genuinely violate the configured keyword, asserting `output: null` so the unsafe rename is covered by a regression test.

`pnpm vitest run` → 82 files, 2379 tests passed. `pnpm lint` (eslint + `eslint-doc-generator --check`) and `tsc --noEmit` are clean.
